### PR TITLE
Update README files to reflect command output format changes for Cisco Nexus parsers

### DIFF
--- a/src/SwitchOutput/Cisco/Nexus/10/environment_temperature_parser/README.md
+++ b/src/SwitchOutput/Cisco/Nexus/10/environment_temperature_parser/README.md
@@ -1,6 +1,6 @@
 # Cisco Nexus Environment Temperature Parser
 
-This parser extracts and formats environment temperature data from Cisco Nexus switch output. It processes the `show environment temperature` command output and converts it into structured JSON format for monitoring and analysis.
+This parser extracts and formats environment temperature data from Cisco Nexus switch output. It processes the `show environment temperature | json` command output and converts it into structured JSON format for monitoring and analysis.
 
 ## Overview
 
@@ -72,6 +72,53 @@ Module   Sensor        MajorThresh   MinorThres   CurTemp     Status
 1        BACK            70              42          26         Ok             
 1        CPU             90              80          42         Ok             
 1        Homewood        110             90          43         Ok 
+```
+
+### JSON Input Format
+
+Command: `show environment temperature | json`
+
+Example file: [show-environment-temperature-json.txt](../show-environment-temperature-json.txt)
+
+```json
+{
+    "TABLE_tempinfo": {
+        "ROW_tempinfo": [
+            {
+                "tempmod": "1",
+                "sensor": "FRONT",
+                "majthres": "80",
+                "minthres": "70",
+                "curtemp": "29",
+                "alarmstatus": "Ok"
+            },
+            {
+                "tempmod": "1",
+                "sensor": "BACK",
+                "majthres": "70",
+                "minthres": "50",
+                "curtemp": "27",
+                "alarmstatus": "Ok"
+            },
+            {
+                "tempmod": "1",
+                "sensor": "CPU",
+                "majthres": "90",
+                "minthres": "80",
+                "curtemp": "36",
+                "alarmstatus": "Ok"
+            },
+            {
+                "tempmod": "1",
+                "sensor": "Heavenly",
+                "majthres": "110",
+                "minthres": "90",
+                "curtemp": "47",
+                "alarmstatus": "Ok"
+            }
+        ]
+    }
+}
 ```
 
 Each temperature entry includes:

--- a/src/SwitchOutput/Cisco/Nexus/10/interface_counters_error_parser/README.md
+++ b/src/SwitchOutput/Cisco/Nexus/10/interface_counters_error_parser/README.md
@@ -1,6 +1,6 @@
 # Cisco Nexus Interface Error Counters Parser
 
-This tool parses Cisco Nexus `show interface counters errors` output and converts it to structured JSON format for monitoring and analysis.
+This tool parses Cisco Nexus `show interface counters errors | json` output and converts it to structured JSON format for monitoring and analysis.
 
 ## Features
 
@@ -198,6 +198,64 @@ Port          Align-Err    FCS-Err   Xmit-Err    Rcv-Err  UnderSize OutDiscards
 mgmt0                   0          0         --         --         --          --
 Eth1/1                  0          0          0          0          0           0
 Po700                   0          0          0          0          0        4303
+```
+
+### Sample Input (JSON)
+
+Complete List: [show-interface-counter-errors.txt](./show-interface-counter-errors.txt)
+
+**Command**: `show interface counters errors | json`
+
+```json
+{
+    "TABLE_interface": {
+        "ROW_interface": [
+            {
+                "interface": "mgmt0",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0"
+            },
+            {
+                "interface": "Ethernet1/1",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            ...
+            {
+                "interface": "port-channel102",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+                        {
+                "interface": "mgmt0"
+            },
+            {
+                "interface": "Ethernet1/1",
+                "eth_indisc": "0"
+            },
+            ...
+            {
+                "interface": "Ethernet1/1",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/2",
+                "eth_stomped_crc": "0"
+            },
+                        {
+                "interface": "port-channel102",
+                "eth_stomped_crc": "0"
+            }
+        ]
+    }
+}
 ```
 
 ### Sample Output

--- a/src/SwitchOutput/Cisco/Nexus/10/interface_counters_error_parser/show-interface-counter-errors.txt
+++ b/src/SwitchOutput/Cisco/Nexus/10/interface_counters_error_parser/show-interface-counter-errors.txt
@@ -318,3 +318,1462 @@ Po101                 0
 Po201                 0
 Po700                 0
 Po701                 0
+CONTOSO-DC1-TOR-01# show interface counters errors | json
+{
+    "TABLE_interface": {
+        "ROW_interface": [
+            {
+                "interface": "mgmt0",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0"
+            },
+            {
+                "interface": "Ethernet1/1",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/2",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/3",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/4",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/5",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/6",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/7",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/8",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/9",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/10",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/11",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/12",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/13",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/14",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/15",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/16",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/17",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/18",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/19",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/20",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/21",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/22",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/23",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/24",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/25",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/26",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/27",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/28",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/29",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/30",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/31",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/32",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/33",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/34",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/35",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/36/1",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/36/2",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/36/3",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "Ethernet1/36/4",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "port-channel50",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "port-channel101",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "port-channel102",
+                "eth_align_err": "0",
+                "eth_fcs_err": "0",
+                "eth_xmit_err": "0",
+                "eth_rcv_err": "0",
+                "eth_undersize": "0",
+                "eth_outdisc": "0"
+            },
+            {
+                "interface": "mgmt0",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0"
+            },
+            {
+                "interface": "Ethernet1/1",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/2",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/3",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/4",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/5",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/6",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/7",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/8",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/9",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/10",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/11",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/12",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/13",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/14",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/15",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/16",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/17",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/18",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/19",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/20",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/21",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/22",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/23",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/24",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/25",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/26",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/27",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/28",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/29",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/30",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/31",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/32",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/33",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/34",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/35",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/36/1",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/36/2",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/36/3",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "Ethernet1/36/4",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "port-channel50",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "port-channel101",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "port-channel102",
+                "eth_single_col": "0",
+                "eth_multi_col": "0",
+                "eth_late_col": "0",
+                "eth_excess_col": "0",
+                "eth_carri_sen": "0",
+                "eth_runts": "0"
+            },
+            {
+                "interface": "mgmt0",
+                "eth_giants": "0",
+                "eth_sqetest_err": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/1",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/2",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/3",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/4",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/5",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/6",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/7",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/8",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/9",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/10",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/11",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/12",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/13",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/14",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/15",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/16",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/17",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/18",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/19",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/20",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/21",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/22",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/23",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/24",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/25",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/26",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/27",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/28",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/29",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/30",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/31",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/32",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/33",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/34",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/35",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/36/1",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/36/2",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/36/3",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "Ethernet1/36/4",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "port-channel50",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "port-channel101",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "port-channel102",
+                "eth_giants": "0",
+                "eth_deferred_tx": "0",
+                "eth_inmactx_err": "0",
+                "eth_inmacrx_err": "0",
+                "eth_symbol_err": "0"
+            },
+            {
+                "interface": "mgmt0"
+            },
+            {
+                "interface": "Ethernet1/1",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/2",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/3",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/4",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/5",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/6",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/7",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/8",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/9",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/10",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/11",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/12",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/13",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/14",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/15",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/16",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/17",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/18",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/19",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/20",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/21",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/22",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/23",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/24",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/25",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/26",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/27",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/28",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/29",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/30",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/31",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/32",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/33",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/34",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/35",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/36/1",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/36/2",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/36/3",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/36/4",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "port-channel50",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "port-channel101",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "port-channel102",
+                "eth_indisc": "0"
+            },
+            {
+                "interface": "Ethernet1/1",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/2",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/3",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/4",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/5",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/6",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/7",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/8",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/9",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/10",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/11",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/12",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/13",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/14",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/15",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/16",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/17",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/18",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/19",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/20",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/21",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/22",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/23",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/24",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/25",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/26",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/27",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/28",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/29",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/30",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/31",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/32",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/33",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/34",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/35",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/36/1",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/36/2",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/36/3",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "Ethernet1/36/4",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "port-channel50",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "port-channel101",
+                "eth_stomped_crc": "0"
+            },
+            {
+                "interface": "port-channel102",
+                "eth_stomped_crc": "0"
+            }
+        ]
+    }
+}

--- a/src/SwitchOutput/Cisco/Nexus/10/show-environment-power-details/README.md
+++ b/src/SwitchOutput/Cisco/Nexus/10/show-environment-power-details/README.md
@@ -1,6 +1,6 @@
 # Cisco Nexus Environment Power Details Parser
 
-This parser processes the output of the `show environment power detail` command from Cisco Nexus switches and converts it to structured JSON format for power monitoring and analysis.
+This parser processes the output of the `show environment power detail | json` command from Cisco Nexus switches and converts it to structured JSON format for power monitoring and analysis.
 
 ## Features
 
@@ -46,7 +46,7 @@ The parser looks for a command named `power-supply` in the commands.json file:
   "commands": [
     {
       "name": "power-supply",
-      "command": "show environment power detail"
+      "command": "show environment power detail | json"
     }
   ]
 }
@@ -79,6 +79,10 @@ The parser outputs JSON Lines format with a standardized structure. Each power e
 ### Message Structure
 
 The `message` field contains comprehensive power data:
+
+Command: `show environment power detail | json`
+
+Example file: [show-environment-power-detail.txt](../show-environment-power-detail.txt)
 
 ```json
 {

--- a/src/SwitchOutput/Cisco/Nexus/10/system-resources/README.md
+++ b/src/SwitchOutput/Cisco/Nexus/10/system-resources/README.md
@@ -1,6 +1,6 @@
 # Cisco Nexus System Resources Parser
 
-This tool parses the output of the `show system resources` command from Cisco Nexus switches and converts it to structured JSON format for monitoring and analysis.
+This tool parses the output of the `show system resources | json` command from Cisco Nexus switches and converts it to structured JSON format for monitoring and analysis.
 
 ## Features
 
@@ -98,6 +98,10 @@ The parser outputs JSON Lines format with a standardized structure compatible wi
 ### Message Fields
 
 The `message` field contains all system resources data:
+
+**Command**: `show system resources | json`
+
+Example file: [show-system-resources.txt](../show-system-resources.txt)
 
 ```json
 {

--- a/src/SwitchOutput/Cisco/Nexus/10/system-uptime/README.md
+++ b/src/SwitchOutput/Cisco/Nexus/10/system-uptime/README.md
@@ -1,6 +1,6 @@
 # Cisco Nexus System Uptime Parser
 
-This tool parses the output of the `show system uptime` command from Cisco Nexus switches and converts it to structured JSON format for system availability monitoring and analysis.
+This tool parses the output of the `show system uptime | json` command from Cisco Nexus switches and converts it to structured JSON format for system availability monitoring and analysis.
 
 ## Features
 
@@ -74,6 +74,10 @@ Kernel uptime:              2 days, 22 hours, 3 minutes, 51 seconds
 ```
 
 ### JSON Format
+
+Command: `show system uptime | json`
+
+Example file: [show-system-uptime-json.txt](../show-system-uptime-json.txt)
 
 ```json
 {


### PR DESCRIPTION
## Description
This PR updates the README documentation for Cisco Nexus parsers to reflect the correct command output format.

## Changes
- Updated README files to accurately document the expected command output format for various Cisco Nexus show commands
- Ensures consistency between documentation and actual parser implementations

## Related Work
- Branch: `emarq-update-parser-readme`
- Commit: 22a0917