### PR TITLE
Unified telemetry schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **gNMI Telemetry Collector** — single Go binary that collects structured YANG
   data via gNMI and ships it to Azure Log Analytics. Replaces the cron-based CLI
   text scraping pipeline.
-  - Cisco NX-OS support: 20 YANG paths (OpenConfig + Cisco native), ~97% parity
+  - Cisco NX-OS support: 21 YANG paths (OpenConfig + Cisco native), ~97% parity
     with legacy CLI parser.
-  - Dell Enterprise SONiC support: 14 YANG paths (OpenConfig), ~76% coverage vs
-    Cisco baseline.
+  - Dell Enterprise SONiC support: 16 YANG paths (OpenConfig + SONiC native),
+    full environment coverage (temperature, PSU, fan).
   - Poll mode (periodic gNMI Get) — production-ready.
   - Subscribe mode (persistent gNMI stream) — supports both `sample` and
     `on_change` per-path modes. Validated on Cisco NX-OS and SONiC.
   - CLI flags: `--once`, `--dry-run`, `--output`, `--dump`, `--verbose`, `--version`.
-- **Per-vendor configuration files**: `config.cisco.yaml` (20 paths) and
-  `config.sonic.yaml` (14 paths) ship in the release tarball.
+- **Per-vendor configuration files**: `config.cisco.yaml` (21 paths) and
+  `config.sonic.yaml` (16 paths) ship in the release tarball.
 - **init.d service script** (`gnmi-collectord`) for Cisco NX-OS daemon management.
 - **Automated onboarding Copilot skill** (`.github/skills/arc-onboarding/`) —
   SSH into a switch, auto-detect vendor, fill setup script, and execute.
@@ -37,7 +37,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - Renamed `config.example.yaml` → `config.cisco.yaml` for clarity.
-- Cisco table names changed from `GnmiTest*` (debug) to `Cisco*_CL` (production).
+- **Unified telemetry schema** — vendor-prefixed table names (`CiscoBgp*`, `SonicBgp*`)
+  replaced with shared tables (`BgpNeighbor_CL`, `EnvTemperature_CL`, etc.). Both
+  platforms write to the same tables; `device_type` distinguishes rows.
+- **Normalized environment fields** — temperature, power supply, and fan transformers
+  now emit consistent field names across Cisco and SONiC (e.g., `high_threshold`,
+  `input_voltage`, `ps_name`).
+- **Added Cisco fan transformer** (`nx-fan`) — Cisco NX-OS now reports fan health
+  to `EnvFan_CL` alongside SONiC, closing the last environment parity gap.
 - Root `README.md` rewritten to lead with Azure Arc + gNMI capabilities.
 - Onboarding README restructured with per-platform installation sections.
 

--- a/Docs/arcnet_onboarding_instructions/README.md
+++ b/Docs/arcnet_onboarding_instructions/README.md
@@ -444,25 +444,23 @@ The following custom tables are created in your Log Analytics workspace (Azure a
 
 | Table Name | Description | Platforms |
 |------------|-------------|-----------|
-| `CiscoInterfaceCounter_CL` | Interface traffic statistics | Cisco, SONiC |
-| `CiscoInterfaceStatus_CL` | Interface admin/oper state | Cisco, SONiC |
-| `CiscoInterfaceEthernet_CL` | Ethernet-specific counters | Cisco, SONiC |
+| `InterfaceCounter_CL` | Interface traffic statistics | Cisco, SONiC |
+| `InterfaceStatus_CL` | Interface admin/oper state | Cisco, SONiC |
+| `InterfaceEthernet_CL` | Ethernet-specific counters | Cisco, SONiC |
 | `CiscoInterfaceErrors_CL` | Interface error counters | Cisco |
-| `CiscoBgpSummary_CL` | BGP neighbor summary | Cisco, SONiC |
-| `CiscoLldpNeighbor_CL` | LLDP neighbor information | Cisco, SONiC |
-| `CiscoTransceiver_CL` | SFP/QSFP module details | Cisco |
-| `CiscoEnvTemp_CL` | Temperature sensors | Cisco, SONiC |
-| `CiscoEnvPower_CL` | Power supply status | Cisco, SONiC |
-| `CiscoEnvFan_CL` | Fan status | Cisco, SONiC |
-| `CiscoSystemResources_CL` | CPU, memory utilization | Cisco, SONiC |
-| `CiscoSystemUptime_CL` | System uptime | Cisco, SONiC |
-| `CiscoIpArp_CL` | ARP table entries | Cisco, SONiC |
-| `CiscoMacAddress_CL` | MAC address table | Cisco, SONiC |
-| `CiscoIpRoute_CL` | Routing table | Cisco, SONiC |
+| `BgpNeighbor_CL` | BGP neighbor summary | Cisco, SONiC |
+| `LldpNeighbor_CL` | LLDP neighbor information | Cisco, SONiC |
+| `Transceiver_CL` | SFP/QSFP module details | Cisco |
+| `EnvTemperature_CL` | Temperature sensors | Cisco, SONiC |
+| `EnvPower_CL` | Power supply status | Cisco, SONiC |
+| `SonicFan_CL` | Fan status | SONiC |
+| `SystemResources_CL` | CPU, memory utilization | Cisco, SONiC |
+| `SystemUptime_CL` | System uptime | Cisco, SONiC |
+| `ArpEntry_CL` | ARP table entries | Cisco, SONiC |
+| `MacTable_CL` | MAC address table | Cisco, SONiC |
 | `CiscoRouteSummary_CL` | Route count summary | Cisco |
-| `CiscoInventory_CL` | Hardware inventory | Cisco |
+| `Inventory_CL` | Hardware inventory | Cisco, SONiC |
 | `CiscoVersion_CL` | Software version info | Cisco |
-| `CiscoClassMap_CL` | QoS class maps | Cisco (CLI only) |
 
 ---
 

--- a/Docs/arcnet_onboarding_instructions/README.md
+++ b/Docs/arcnet_onboarding_instructions/README.md
@@ -223,7 +223,7 @@ for svc in himdsd arcproxyd extd gcad; do /etc/init.d/$svc status; done
 /opt/gnmi-collector/gnmi-collector --config /opt/gnmi-collector/config.yaml --once --dry-run
 ```
 
-**Telemetry paths collected** (20 paths): Interface counters, interface status, interface Ethernet, interface errors, BGP neighbors, BGP summary, LLDP, transceiver DOM, environment temperature, environment power, environment fan, system resources, system uptime, system version, ARP, MAC addresses, IP routes, route summary, inventory, platform components.
+**Telemetry paths collected** (21 paths): Interface counters, interface status, interface Ethernet, interface errors, BGP neighbors, BGP global, LLDP, transceiver, transceiver DOM, environment temperature, environment power, environment fan, system resources, system uptime, system version, ARP, MAC addresses, route summary, inventory.
 
 ---
 
@@ -360,7 +360,7 @@ systemctl status gnmi-collector
 /opt/gnmi-collector/gnmi-collector --config /opt/gnmi-collector/config.yaml --once --dry-run
 ```
 
-**Telemetry paths collected** (14 paths): Interface counters, interface status, interface Ethernet, BGP neighbors, BGP summary, LLDP, environment (platform inventory: temperature, PSU, fans), system resources, system uptime, ARP, MAC addresses, IP routes.
+**Telemetry paths collected** (16 paths): Interface counters, interface status, interface Ethernet, BGP neighbors, BGP global, LLDP, environment temperature, environment power, environment fan, system resources, system uptime, ARP, MAC addresses, inventory, platform components, device metadata.
 
 ---
 
@@ -427,7 +427,7 @@ search "*"
 | where Type endswith "_CL"
 
 // Example: Query interface counters
-CiscoInterfaceCounter_CL
+InterfaceCounter_CL
 | where TimeGenerated > ago(1h)
 | take 10
 
@@ -449,11 +449,13 @@ The following custom tables are created in your Log Analytics workspace (Azure a
 | `InterfaceEthernet_CL` | Ethernet-specific counters | Cisco, SONiC |
 | `CiscoInterfaceErrors_CL` | Interface error counters | Cisco |
 | `BgpNeighbor_CL` | BGP neighbor summary | Cisco, SONiC |
+| `BgpGlobal_CL` | BGP global state | Cisco, SONiC |
 | `LldpNeighbor_CL` | LLDP neighbor information | Cisco, SONiC |
 | `Transceiver_CL` | SFP/QSFP module details | Cisco |
+| `TransceiverDom_CL` | Transceiver DOM (Tx/Rx power) | Cisco |
 | `EnvTemperature_CL` | Temperature sensors | Cisco, SONiC |
 | `EnvPower_CL` | Power supply status | Cisco, SONiC |
-| `SonicFan_CL` | Fan status | SONiC |
+| `EnvFan_CL` | Fan health and status | Cisco, SONiC |
 | `SystemResources_CL` | CPU, memory utilization | Cisco, SONiC |
 | `SystemUptime_CL` | System uptime | Cisco, SONiC |
 | `ArpEntry_CL` | ARP table entries | Cisco, SONiC |
@@ -461,6 +463,7 @@ The following custom tables are created in your Log Analytics workspace (Azure a
 | `CiscoRouteSummary_CL` | Route count summary | Cisco |
 | `Inventory_CL` | Hardware inventory | Cisco, SONiC |
 | `CiscoVersion_CL` | Software version info | Cisco |
+| `SonicDeviceMetadata_CL` | Device metadata | SONiC |
 
 ---
 

--- a/Docs/telemetry-improvement-plan/cisco-nxos-parity.md
+++ b/Docs/telemetry-improvement-plan/cisco-nxos-parity.md
@@ -310,8 +310,8 @@ Global join), CLI-only power aggregations, and `vmalloc` (not in any YANG model)
 |-------|:---:|:----:|
 | `module` / `sensor` | ✅ | ✅ |
 | `current_temp` | ✅ | ✅ |
-| `major_threshold` | ✅ | ✅ |
-| `minor_threshold` | ✅ | ✅ |
+| `high_threshold` | ✅ | ✅ |
+| `low_threshold` | ✅ | ✅ |
 | `status` | ✅ | ✅ |
 
 > Uses native YANG (`nx-env-sensor`).
@@ -325,16 +325,16 @@ Global join), CLI-only power aggregations, and `vmalloc` (not in any YANG model)
 
 | Field | CLI | gNMI |
 |-------|:---:|:----:|
-| `name` / `ps_number` | ✅ | ✅ |
+| `ps_name` | ✅ | ✅ |
 | `model` | ✅ | ✅ |
 | `serial` | ✅ | ✅ |
 | `status` | ✅ | ✅ |
 | `total_capacity` | ✅ | ✅ |
-| `input_voltage` (`vin`) | ✅ | ✅ |
-| `input_current` (`iin`) | ✅ | ✅ |
-| `output_voltage` (`vout`) | ✅ | ✅ |
-| `output_current` (`iout`) | ✅ | ✅ |
-| `output_power` (`pout`) | ✅ | ✅ |
+| `input_voltage` | ✅ | ✅ |
+| `input_current` | ✅ | ✅ |
+| `output_voltage` | ✅ | ✅ |
+| `output_current` | ✅ | ✅ |
+| `output_power` | ✅ | ✅ |
 | `vendor` | — | ✅ |
 | `fan_direction` / `fan_status` | ✅ | ✅ |
 | `cord_status` | ✅ | ✅ |

--- a/Docs/telemetry-improvement-plan/cisco-nxos-parity.md
+++ b/Docs/telemetry-improvement-plan/cisco-nxos-parity.md
@@ -2,8 +2,8 @@
 
 > **Last updated**: 2026-04-10  
 > **Test switch**: rr1-n42-r07-9336hl-13-1a (100.71.34.149) — NX-OS 1.2407.41 (x86_64)  
-> **Collector config**: 20 gNMI paths, all validated  
-> **Dry-run result**: 20 success, 0 failures in 11.7s  
+> **Collector config**: 21 gNMI paths, all validated  
+> **Dry-run result**: 21 success, 0 failures in 11.7s  
 > **Coverage vs CLI**: **~97%**
 
 Cisco gNMI **exceeds** CLI in several categories (BGP detail, interface errors,
@@ -425,6 +425,24 @@ Global join), CLI-only power aggregations, and `vmalloc` (not in any YANG model)
 
 ---
 
+### 19. Environment — Fan
+
+| Field | CLI | gNMI |
+|-------|:---:|:----:|
+| `name` | ✅ | ✅ |
+| `model` | ✅ | ✅ |
+| `serial` | — | ✅ |
+| `fan_direction` | ✅ | ✅ |
+| `fan_status` | ✅ | ✅ |
+
+> Uses native YANG (`/System/ch-items/ftslot-items/FtSlot-list`).
+> NX-OS has 3 fan trays × 4 fans per tray = 12 system fans + 2 PSU-embedded fans.
+
+**Records**: 14 fans  
+**Parity**: ✅ **100%** — gNMI adds serial number
+
+---
+
 ## Record Counts (from validated dry-run, 2026-04-09)
 
 | Table | Records |
@@ -443,6 +461,7 @@ Global join), CLI-only power aggregations, and `vmalloc` (not in any YANG model)
 | MacTable | 1,224 |
 | EnvTemperature | 4 |
 | EnvPower | 1 (2 PSUs) |
+| EnvFan | 14 |
 | Transceiver | 63 (20 with optics) |
 | TransceiverDom | 20 |
 | RouteSummary | 2 |
@@ -463,8 +482,8 @@ domain-level attributes like `asn`. Both approaches were attempted:
 (value: `64781`). A KQL join on `vrf_name` provides the same data:
 
 ```kql
-CiscoBgpSummary_CL
-| join kind=leftouter (CiscoBgpGlobal_CL | project vrf_name, vrf_local_as=local_as) on vrf_name
+BgpNeighbor_CL
+| join kind=leftouter (BgpGlobal_CL | project vrf_name, vrf_local_as=local_as) on vrf_name
 ```
 
 ---

--- a/Docs/telemetry-improvement-plan/data-parity-overview.md
+++ b/Docs/telemetry-improvement-plan/data-parity-overview.md
@@ -1,6 +1,6 @@
 # Telemetry Data Parity — Overview
 
-> **Last updated**: 2026-04-10  
+> **Last updated**: 2026-04-20  
 > **Purpose**: Cross-vendor summary of gNMI telemetry data collection parity
 
 This directory contains per-vendor data parity reports for the `gnmi-collector`.
@@ -36,7 +36,7 @@ exists, compares field-by-field coverage.
 | MAC Table | ✅ 7 | ✅ 12 | ⚠️ 0* | *L3-only switch, not a code issue |
 | Env Temperature | ✅ 6 | ✅ 6 | ✅ 6 | **Parity achieved** |
 | Env Power Supply | ✅ 20 | ⚠️ 14 | ⚠️ 10 | CLI aggregations missing |
-| Env Fan | ✅ 3 | — | ✅ 7 | SONiC-only via sonic-platform |
+| Env Fan | ✅ 3 | ✅ 5 | ✅ 7 | **Parity achieved** — unified to EnvFan_CL |
 | Transceiver | ✅ 16 | ✅ 14 | ❌ 0 | SONiC: disabled (needs per-intf keys) |
 | Transceiver DOM | ✅ 5 | ✅ 5 | ❌ 0 | SONiC: disabled |
 | Route Summary | ✅ 3 | ✅ 4 | ❌ 0 | SONiC: no YANG model |

--- a/Docs/telemetry-improvement-plan/data-parity-overview.md
+++ b/Docs/telemetry-improvement-plan/data-parity-overview.md
@@ -55,7 +55,7 @@ exists, compares field-by-field coverage.
 | **QoS / Class Map** | OpenConfig QoS models exist but no vendor implements them via gNMI |
 | **Power aggregations** (total_grid_*, total_power_*) | CLI-only computed values, not raw device data |
 | **vmalloc** | Linux kernel metric, not exposed via any YANG model |
-| **Table naming** — `Cisco*_CL` prefix (Cisco), `Sonic*_CL` prefix (SONiC) | Production naming convention matching Azure Log Analytics `_CL` suffix |
+| **Table naming** — Unified tables for shared data types (e.g., `BgpNeighbor_CL`), vendor-prefixed only for vendor-specific tables | See [unified-schema.md](unified-schema.md) for full mapping |
 
 ---
 
@@ -66,3 +66,5 @@ exists, compares field-by-field coverage.
 - **Both poll and subscribe modes** are validated with 100% data parity between modes.
 - **Zero config changes to switches** — read-only gNMI subscriptions only.
 - **Arc-integrated** — runs as init.d (NX-OS) or systemd (SONiC/Linux) service.
+- **Unified schema** — Shared data types land in the same Kusto tables across vendors.
+  See [unified-schema.md](unified-schema.md) for the full mapping and migration guide.

--- a/Docs/telemetry-improvement-plan/sonic-gnmi-parity.md
+++ b/Docs/telemetry-improvement-plan/sonic-gnmi-parity.md
@@ -2,7 +2,7 @@
 
 > **Last updated**: 2026-04-10  
 > **Test switch**: b88-c01-5248l-7-1a (100.100.81.129) — Dell Enterprise SONiC 4.5.1 (x86_64)  
-> **Collector config**: 14 gNMI paths, all validated  
+> **Collector config**: 16 gNMI paths, all validated  
 > **Dry-run result**: 14 success, 0 failures in 7.4s  
 > **Coverage vs Cisco CLI baseline**: **~76%**
 

--- a/Docs/telemetry-improvement-plan/telemetry-tables.md
+++ b/Docs/telemetry-improvement-plan/telemetry-tables.md
@@ -16,25 +16,26 @@ of tables, distinguished by the `device_type` column.
 
 | # | Table Name | Category | Cisco | SONiC | Description |
 |---|-----------|----------|:-----:|:-----:|-------------|
-| 1 | `InterfaceCounter_v2_CL` | Interfaces | ✅ | ✅ | Per-interface traffic counters (bytes, packets, unicast, multicast, broadcast, errors, discards) |
-| 2 | `InterfaceStatus_v2_CL` | Interfaces | ✅ | ✅ | Interface operational and admin state (up/down, speed, MTU, description) |
-| 3 | `InterfaceEthernet_v2_CL` | Interfaces | ✅ | ✅ | Ethernet-specific state (speed, duplex, auto-negotiate, CRC/fragment/jabber counters) |
-| 4 | `InterfaceErrors_v2_CL` | Interfaces | ✅ | — | Detailed L1/L2 error counters (CRC, collisions, runts, jabbers, overruns) via Cisco-native YANG |
-| 5 | `SystemUptime_v2_CL` | System | ✅ | ✅ | System hostname, boot time, uptime, and current date/time |
-| 6 | `SystemResources_v2_CL` | System | ✅ | ✅ | CPU utilization (per-core), memory usage, and load averages |
-| 7 | `Inventory_v2_CL` | Platform | ✅ | ✅ | Hardware inventory — chassis, line cards, fans, PSUs, CPUs, transceivers with serial numbers and descriptions |
-| 8 | `BgpSummary_v2_CL` | Routing | ✅ | ✅ | Per-neighbor BGP session state, AS numbers, message counts, prefix counts, and uptime |
-| 9 | `BgpGlobal_v2_CL` | Routing | ✅ | ✅ | BGP global state — router ID, local AS, total paths and prefixes |
-| 10 | `RouteSummary_v2_CL` | Routing | ✅ | — | IPv4 route summary per VRF — total routes, paths, and multipath counts (Cisco-native YANG) |
-| 11 | `LldpNeighbor_v2_CL` | Discovery | ✅ | ✅ | LLDP neighbor table — local port, remote system name, remote port, chassis ID, capabilities |
-| 12 | `ArpEntry_v2_CL` | Discovery | ✅ | ✅ | ARP/neighbor table — IP address, MAC address, interface, entry type |
-| 13 | `MacTable_v2_CL` | Discovery | ✅ | ✅ | MAC address table — MAC, VLAN, port, type (static/dynamic) |
-| 14 | `EnvTemp_v2_CL` | Environment | ✅ | — | Temperature sensor readings with thresholds and alert status (Cisco-native YANG) |
-| 15 | `EnvPower_v2_CL` | Environment | ✅ | — | Power supply status, voltage, current, and wattage per PSU (Cisco-native YANG) |
-| 16 | `Transceiver_v2_CL` | Optics | ✅ | ✅ | Transceiver presence, type, manufacturer, part/serial numbers |
-| 17 | `TransceiverDom_v2_CL` | Optics | ✅ | ✅ | Transceiver DOM — optical Tx/Rx power, laser bias current per channel |
-| 18 | `Version_v2_CL` | System | ✅ | — | NX-OS version, system image, system name, serial number (Cisco-native YANG) |
-| 19 | `DeviceMetadata_v2_CL` | System | — | ✅ | SONiC device metadata — hostname, hardware SKU, platform, MAC address |
+| 1 | `InterfaceCounter_CL` | Interfaces | ✅ | ✅ | Per-interface traffic counters (bytes, packets, unicast, multicast, broadcast, errors, discards) |
+| 2 | `InterfaceStatus_CL` | Interfaces | ✅ | ✅ | Interface operational and admin state (up/down, speed, MTU, description) |
+| 3 | `InterfaceEthernet_CL` | Interfaces | ✅ | ✅ | Ethernet-specific state (speed, duplex, auto-negotiate, CRC/fragment/jabber counters) |
+| 4 | `CiscoInterfaceErrors_CL` | Interfaces | ✅ | — | Detailed L1/L2 error counters (CRC, collisions, runts, jabbers, overruns) via Cisco-native YANG |
+| 5 | `SystemUptime_CL` | System | ✅ | ✅ | System hostname, boot time, uptime, and current date/time |
+| 6 | `SystemResources_CL` | System | ✅ | ✅ | CPU utilization (per-core), memory usage, and load averages |
+| 7 | `Inventory_CL` | Platform | ✅ | ✅ | Hardware inventory — chassis, line cards, fans, PSUs, CPUs, transceivers with serial numbers and descriptions |
+| 8 | `BgpNeighbor_CL` | Routing | ✅ | ✅ | Per-neighbor BGP session state, AS numbers, message counts, prefix counts, and uptime |
+| 9 | `BgpGlobal_CL` | Routing | ✅ | ✅ | BGP global state — router ID, local AS, total paths and prefixes |
+| 10 | `CiscoRouteSummary_CL` | Routing | ✅ | — | IPv4 route summary per VRF — total routes, paths, and multipath counts (Cisco-native YANG) |
+| 11 | `LldpNeighbor_CL` | Discovery | ✅ | ✅ | LLDP neighbor table — local port, remote system name, remote port, chassis ID, capabilities |
+| 12 | `ArpEntry_CL` | Discovery | ✅ | ✅ | ARP/neighbor table — IP address, MAC address, interface, entry type |
+| 13 | `MacTable_CL` | Discovery | ✅ | ✅ | MAC address table — MAC, VLAN, port, type (static/dynamic) |
+| 14 | `EnvTemperature_CL` | Environment | ✅ | ✅ | Temperature sensor readings with thresholds and alert status |
+| 15 | `EnvPower_CL` | Environment | ✅ | ✅ | Power supply status, voltage, current, and wattage per PSU |
+| 16 | `EnvFan_CL` | Environment | ✅ | ✅ | Fan health — name, model, direction, status, serial number |
+| 17 | `Transceiver_CL` | Optics | ✅ | — | Transceiver presence, type, manufacturer, part/serial numbers |
+| 18 | `TransceiverDom_CL` | Optics | ✅ | — | Transceiver DOM — optical Tx/Rx power, laser bias current per channel |
+| 19 | `CiscoVersion_CL` | System | ✅ | — | NX-OS version, system image, system name, serial number (Cisco-native YANG) |
+| 20 | `SonicDeviceMetadata_CL` | System | — | ✅ | SONiC device metadata — hostname, hardware SKU, platform, MAC address |
 
 ---
 
@@ -47,15 +48,15 @@ System / Resources        ██████████████████
 Platform Inventory        ████████████████████
 BGP Routing               ████████████████████
 LLDP / ARP / MAC          ████████████████████
-Environment (Temp/PSU)    ██████████
-Optics (Transceiver/DOM)  ████████████████████
+Environment (Temp/PSU/Fan)████████████████████
+Optics (Transceiver/DOM)  ██████████
 Route Summary             ██████████
 Version / Metadata        ████████████████████
 ```
 
-Cisco NX-OS has full coverage across all 18 table categories. SONiC covers
-13 of 18 — the gaps are Cisco-native YANG paths (interface errors, route
-summary, environment sensors) that have no OpenConfig equivalent on SONiC.
+Cisco NX-OS has full coverage across all 20 table categories. SONiC covers
+16 of 20 — the gaps are transceiver/DOM (disabled, needs per-interface keys),
+route summary (no YANG model), and interface errors (no YANG model).
 
 ---
 
@@ -149,7 +150,7 @@ Common columns across all tables:
 
 ```kql
 // Show latest BGP peer state across all switches
-BgpSummary_v2_CL
+BgpNeighbor_CL
 | where TimeGenerated > ago(1h)
 | summarize arg_max(TimeGenerated, *) by device_type_s, hostname_s, message_neighbor_address_s
 | project TimeGenerated, device_type_s, hostname_s, message_neighbor_address_s, message_neighbor_as_s, message_msg_recvd_d, message_msg_sent_d

--- a/Docs/telemetry-improvement-plan/unified-schema.md
+++ b/Docs/telemetry-improvement-plan/unified-schema.md
@@ -1,0 +1,164 @@
+# Unified Telemetry Schema
+
+> **Last updated**: 2026-07-14  
+> **Branch**: `users/camilose/unified-telemetry-schema`  
+> **Purpose**: Document the unified table schema that consolidates Cisco and SONiC telemetry into shared tables.
+
+## Overview
+
+Previously, Cisco and SONiC telemetry landed in vendor-prefixed tables (e.g.,
+`CiscoBgpSummary_CL` vs `SonicBgpSummary_CL`). Both platforms share the same
+OpenConfig models and produce identical or superset schemas, yet operators had to
+write vendor-specific queries.
+
+The unified schema eliminates vendor prefixes for shared data types. Cross-vendor
+queries now work against a single table, with `device_type` serving as the vendor
+discriminator when needed.
+
+## Design Principles
+
+1. **Vendor-neutral `data_type` constants** — Transformers emit canonical names
+   like `bgp_summary`, `interface_counters` instead of `cisco_nexus_bgp_summary`.
+
+2. **Unified table names** — Both `config.cisco.yaml` and `config.sonic.yaml`
+   point to the same Kusto table for shared data types.
+
+3. **`device_type` as vendor discriminator** — Already injected by `azure.Logger`
+   into every record. No new column needed.
+
+4. **Sparse columns are fine** — Cisco native transformers emit extra fields
+   (e.g., `hold_interval`, `connection_drops`). SONiC rows simply lack those
+   columns. Kusto handles sparse data natively.
+
+5. **Incompatible row shapes stay separate** — `EnvPower` has different grain
+   (Cisco: one row with PSU array; SONiC: one row per PSU). These remain in
+   vendor-specific tables until row shape is normalized.
+
+---
+
+## Unified Table Mapping
+
+### Shared Tables (cross-vendor queries supported)
+
+| Table | data_type | Cisco Source | SONiC Source | Notes |
+|---|---|---|---|---|
+| `InterfaceCounter_CL` | `interface_counters` | interface_counters.go | same | Identical schema |
+| `InterfaceStatus_CL` | `interface_status` | interface_status.go | same | Identical schema |
+| `InterfaceEthernet_CL` | `interface_ethernet` | interface_ethernet.go | same | Identical schema |
+| `BgpNeighbor_CL` | `bgp_summary` | native_bgp.go (superset) | bgp_summary.go | Cisco adds hold_interval, connection_drops, etc. |
+| `BgpGlobal_CL` | `bgp_global` | bgp_global.go | same | Identical schema |
+| `ArpEntry_CL` | `arp_entry` | native_arp.go (superset) | arp.go | Cisco adds phy_interface, flags |
+| `LldpNeighbor_CL` | `lldp_neighbor` | native_lldp.go (superset) | lldp_neighbor.go | Cisco adds mgmt_addr, mgmt_addr_type, ttl |
+| `MacTable_CL` | `mac_table` | native_mac.go (superset) | mac_address.go | Cisco adds entry_type, is_static |
+| `SystemUptime_CL` | `system_uptime` | system.go | same | Identical schema |
+| `SystemResources_CL` | `system_resources` | native_system.go (superset) | system.go | Cisco adds kernel, user CPU, etc. |
+| `Inventory_CL` | `inventory` | inventory.go | same | Identical schema |
+| `Transceiver_CL` | `transceiver` | native_transceiver.go (superset) | transceiver.go | Cisco adds connector_type, ethernet_pmd |
+| `TransceiverDom_CL` | `transceiver_dom` | transceiver_dom | transceiver_channel.go | same |
+| `EnvTemperature_CL` | `environment_temperature` | native_environment.go | sonic_platform.go (split) | Cisco: major/minor thresholds; SONiC: high/critical_high/low |
+
+### Vendor-Specific Tables (no cross-vendor equivalent)
+
+| Table | data_type | Vendor | Reason |
+|---|---|---|---|
+| `CiscoEnvPower_CL` | `environment_power` | Cisco | One row with PSU array — incompatible with SONiC grain |
+| `CiscoVersion_CL` | `version` | Cisco | NX-OS-specific version model |
+| `CiscoInterfaceErrors_CL` | `interface_error_counters` | Cisco | No SONiC YANG model |
+| `CiscoRouteSummary_CL` | `route_summary` | Cisco | No SONiC YANG model |
+| `SonicDeviceMetadata_CL` | `device_metadata` | SONiC | SONiC-specific metadata |
+| `SonicFan_CL` | `fan` | SONiC | SONiC-specific fan model |
+| `SonicEnvPower_CL` | `psu` | SONiC | Per-PSU rows — incompatible with Cisco grain |
+
+---
+
+## Breaking Changes
+
+### Table Name Migration
+
+If you have dashboards or alerts querying the old table names, update them:
+
+| Old Cisco Table | Old SONiC Table | New Unified Table |
+|---|---|---|
+| `CiscoInterfaceCounters_CL` | `SonicInterfaceCounters_CL` | `InterfaceCounter_CL` |
+| `CiscoInterfaceStatus_CL` | `SonicInterfaceStatus_CL` | `InterfaceStatus_CL` |
+| `CiscoInterfaceEthernet_CL` | `SonicInterfaceEthernet_CL` | `InterfaceEthernet_CL` |
+| `CiscoBgpSummary_CL` | `SonicBgpSummary_CL` | `BgpNeighbor_CL` |
+| `CiscoBgpGlobal_CL` | `SonicBgpGlobal_CL` | `BgpGlobal_CL` |
+| `CiscoArpEntry_CL` | `SonicArpEntry_CL` | `ArpEntry_CL` |
+| `CiscoLldpNeighbor_CL` | `SonicLldpNeighbor_CL` | `LldpNeighbor_CL` |
+| `CiscoMacTable_CL` | `SonicMacTable_CL` | `MacTable_CL` |
+| `CiscoSystemUptime_CL` | `SonicSystemUptime_CL` | `SystemUptime_CL` |
+| `CiscoSystemResources_CL` | `SonicSystemResources_CL` | `SystemResources_CL` |
+| `CiscoInventory_CL` | `SonicInventory_CL` | `Inventory_CL` |
+| `CiscoTransceiver_CL` | — | `Transceiver_CL` |
+| `CiscoTransceiverDom_CL` | — | `TransceiverDom_CL` |
+| `CiscoEnvTemperature_CL` | `SonicEnvTemperature_CL` | `EnvTemperature_CL` |
+
+> **Note**: Historical data in Kusto remains under old table names. New data flows
+> to the unified names after deployment.
+
+### data_type Field Changes
+
+The `data_type` field in every record has been renamed from vendor-prefixed to
+vendor-neutral. Queries filtering on `data_type` must be updated:
+
+| Old value | New value |
+|---|---|
+| `cisco_nexus_interface_counters` | `interface_counters` |
+| `cisco_nexus_bgp_summary` | `bgp_summary` |
+| `cisco_nexus_arp_entry` | `arp_entry` |
+| `cisco_nexus_lldp_neighbor` | `lldp_neighbor` |
+| `cisco_nexus_mac_table` | `mac_table` |
+| ... (all `cisco_nexus_*` prefixes removed) | |
+
+---
+
+## Querying Unified Tables
+
+### Cross-vendor query (all BGP neighbors)
+
+```kql
+BgpNeighbor_CL
+| where TimeGenerated > ago(1h)
+| summarize count() by device_type, neighbor_address
+```
+
+### Filter by vendor
+
+```kql
+InterfaceCounter_CL
+| where device_type == "cisco_nexus"
+| summarize avg(in_octets) by interface_name, bin(TimeGenerated, 5m)
+```
+
+### Handle sparse fields
+
+```kql
+BgpNeighbor_CL
+| extend hold_interval = coalesce(hold_interval, 0)
+| project device_type, neighbor_address, hold_interval
+```
+
+---
+
+## Implementation Details
+
+### sonic_platform Split
+
+The SONiC `sonic-platform` gNMI path returns temperature, PSU, and fan data in a
+single response. Since the collector routes all entries from one path to one table,
+the transformer was split into three:
+
+- `SonicTemperatureTransformer` → registers as `sonic-temperature` → `EnvTemperature_CL`
+- `SonicPsuTransformer` → registers as `sonic-psu` → `SonicEnvPower_CL`
+- `SonicFanTransformer` → registers as `sonic-fan` → `SonicFan_CL`
+
+All three query the same gNMI path (`/sonic-platform:sonic-platform`) but extract
+only their relevant data type from the response.
+
+### Prefix System Removed
+
+The `applyDataTypePrefix()` function in `collector.go` previously rewrote data_type
+values at runtime (e.g., prepending `cisco_nexus_` to `bgp_summary`). This is no
+longer needed since transformer constants are already vendor-neutral. Functions
+removed: `applyDataTypePrefix()`, `DataTypePrefix()`, `DeviceTypeToPrefix()`.

--- a/Docs/telemetry-improvement-plan/unified-schema.md
+++ b/Docs/telemetry-improvement-plan/unified-schema.md
@@ -1,6 +1,6 @@
 # Unified Telemetry Schema
 
-> **Last updated**: 2026-07-14  
+> **Last updated**: 2026-04-18  
 > **Branch**: `users/camilose/unified-telemetry-schema`  
 > **Purpose**: Document the unified table schema that consolidates Cisco and SONiC telemetry into shared tables.
 
@@ -30,9 +30,9 @@ discriminator when needed.
    (e.g., `hold_interval`, `connection_drops`). SONiC rows simply lack those
    columns. Kusto handles sparse data natively.
 
-5. **Incompatible row shapes stay separate** — `EnvPower` has different grain
-   (Cisco: one row with PSU array; SONiC: one row per PSU). These remain in
-   vendor-specific tables until row shape is normalized.
+5. **Row shapes normalized where possible** — `EnvPower` was originally split
+   (Cisco: one row with PSU array; SONiC: one row per PSU). Both now emit flat
+   per-PSU rows, enabling a unified `EnvPower_CL` table.
 
 ---
 
@@ -55,19 +55,19 @@ discriminator when needed.
 | `Inventory_CL` | `inventory` | inventory.go | same | Identical schema |
 | `Transceiver_CL` | `transceiver` | native_transceiver.go (superset) | transceiver.go | Cisco adds connector_type, ethernet_pmd |
 | `TransceiverDom_CL` | `transceiver_dom` | transceiver_dom | transceiver_channel.go | same |
-| `EnvTemperature_CL` | `environment_temperature` | native_environment.go | sonic_platform.go (split) | Cisco: major/minor thresholds; SONiC: high/critical_high/low |
+| `EnvTemperature_CL` | `environment_temperature` | native_environment.go | sonic_platform.go | All platforms use high_threshold, low_threshold, critical_high_threshold |
+| `EnvPower_CL` | `environment_power` | native_environment.go | sonic_platform.go | Cisco adds vendor, cord_status, fan fields |
 
 ### Vendor-Specific Tables (no cross-vendor equivalent)
 
 | Table | data_type | Vendor | Reason |
 |---|---|---|---|
-| `CiscoEnvPower_CL` | `environment_power` | Cisco | One row with PSU array — incompatible with SONiC grain |
 | `CiscoVersion_CL` | `version` | Cisco | NX-OS-specific version model |
 | `CiscoInterfaceErrors_CL` | `interface_error_counters` | Cisco | No SONiC YANG model |
 | `CiscoRouteSummary_CL` | `route_summary` | Cisco | No SONiC YANG model |
 | `SonicDeviceMetadata_CL` | `device_metadata` | SONiC | SONiC-specific metadata |
 | `SonicFan_CL` | `fan` | SONiC | SONiC-specific fan model |
-| `SonicEnvPower_CL` | `psu` | SONiC | Per-PSU rows — incompatible with Cisco grain |
+
 
 ---
 
@@ -93,6 +93,7 @@ If you have dashboards or alerts querying the old table names, update them:
 | `CiscoTransceiver_CL` | — | `Transceiver_CL` |
 | `CiscoTransceiverDom_CL` | — | `TransceiverDom_CL` |
 | `CiscoEnvTemperature_CL` | `SonicEnvTemperature_CL` | `EnvTemperature_CL` |
+| `CiscoEnvPower_CL` | `SonicEnvPower_CL` | `EnvPower_CL` |
 
 > **Note**: Historical data in Kusto remains under old table names. New data flows
 > to the unified names after deployment.
@@ -150,7 +151,7 @@ single response. Since the collector routes all entries from one path to one tab
 the transformer was split into three:
 
 - `SonicTemperatureTransformer` → registers as `sonic-temperature` → `EnvTemperature_CL`
-- `SonicPsuTransformer` → registers as `sonic-psu` → `SonicEnvPower_CL`
+- `SonicPsuTransformer` → registers as `sonic-psu` → `EnvPower_CL`
 - `SonicFanTransformer` → registers as `sonic-fan` → `SonicFan_CL`
 
 All three query the same gNMI path (`/sonic-platform:sonic-platform`) but extract

--- a/Docs/telemetry-improvement-plan/unified-schema.md
+++ b/Docs/telemetry-improvement-plan/unified-schema.md
@@ -1,6 +1,6 @@
 # Unified Telemetry Schema
 
-> **Last updated**: 2026-04-18  
+> **Last updated**: 2026-04-20  
 > **Branch**: `users/camilose/unified-telemetry-schema`  
 > **Purpose**: Document the unified table schema that consolidates Cisco and SONiC telemetry into shared tables.
 
@@ -57,6 +57,7 @@ discriminator when needed.
 | `TransceiverDom_CL` | `transceiver_dom` | transceiver_dom | transceiver_channel.go | same |
 | `EnvTemperature_CL` | `environment_temperature` | native_environment.go | sonic_platform.go | All platforms use high_threshold, low_threshold, critical_high_threshold |
 | `EnvPower_CL` | `environment_power` | native_environment.go | sonic_platform.go | Cisco adds vendor, cord_status, fan fields |
+| `EnvFan_CL` | `fan` | native_environment.go | sonic_platform.go | Cisco: name, model, direction, status, serial; SONiC adds speed, drawer_name |
 
 ### Vendor-Specific Tables (no cross-vendor equivalent)
 
@@ -66,7 +67,6 @@ discriminator when needed.
 | `CiscoInterfaceErrors_CL` | `interface_error_counters` | Cisco | No SONiC YANG model |
 | `CiscoRouteSummary_CL` | `route_summary` | Cisco | No SONiC YANG model |
 | `SonicDeviceMetadata_CL` | `device_metadata` | SONiC | SONiC-specific metadata |
-| `SonicFan_CL` | `fan` | SONiC | SONiC-specific fan model |
 
 
 ---
@@ -94,6 +94,7 @@ If you have dashboards or alerts querying the old table names, update them:
 | `CiscoTransceiverDom_CL` | — | `TransceiverDom_CL` |
 | `CiscoEnvTemperature_CL` | `SonicEnvTemperature_CL` | `EnvTemperature_CL` |
 | `CiscoEnvPower_CL` | `SonicEnvPower_CL` | `EnvPower_CL` |
+| — | `SonicFan_CL` | `EnvFan_CL` |
 
 > **Note**: Historical data in Kusto remains under old table names. New data flows
 > to the unified names after deployment.
@@ -152,7 +153,7 @@ the transformer was split into three:
 
 - `SonicTemperatureTransformer` → registers as `sonic-temperature` → `EnvTemperature_CL`
 - `SonicPsuTransformer` → registers as `sonic-psu` → `EnvPower_CL`
-- `SonicFanTransformer` → registers as `sonic-fan` → `SonicFan_CL`
+- `SonicFanTransformer` → registers as `sonic-fan` → `EnvFan_CL`
 
 All three query the same gNMI path (`/sonic-platform:sonic-platform`) but extract
 only their relevant data type from the response.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Arc-Switch enables you to onboard network switches to [Azure Arc](https://learn.
 
 | Platform | Telemetry | Method | Status |
 |----------|-----------|--------|--------|
-| **Cisco NX-OS** | gNMI *(recommended)* | 20 YANG paths via gRPC | ✅ Production |
+| **Cisco NX-OS** | gNMI *(recommended)* | 21 YANG paths via gRPC | ✅ Production |
 | **Cisco NX-OS** | CLI parser *(legacy)* | `vsh` text scraping + cron | ⚠️ Deprecated |
-| **Dell Enterprise SONiC** | gNMI | 14 YANG paths via gRPC | ✅ Production |
+| **Dell Enterprise SONiC** | gNMI | 16 YANG paths via gRPC | ✅ Production |
 | **Dell OS10** | CLI parser | `clish` text scraping + cron | ✅ Production |
 
 ## Quick Start
@@ -31,8 +31,8 @@ arc-switch/
 │   ├── TelemetryClient/              # gNMI telemetry collector (Go)
 │   │   ├── cmd/gnmi-collector/       # Main binary entry point
 │   │   ├── internal/                 # Collector, transformers, Azure logger
-│   │   ├── config.cisco.yaml         # Cisco NX-OS config (20 paths)
-│   │   └── config.sonic.yaml         # SONiC config (14 paths)
+│   │   ├── config.cisco.yaml         # Cisco NX-OS config (21 paths)
+│   │   └── config.sonic.yaml         # SONiC config (16 paths)
 │   └── SwitchOutput/                 # Legacy CLI parsers
 │       ├── Cisco/Nexus/10/           # Cisco unified parser (Go)
 │       └── DellOS/10/               # Dell OS10 unified parser (Go)

--- a/src/TelemetryClient/config.cisco.yaml
+++ b/src/TelemetryClient/config.cisco.yaml
@@ -120,7 +120,7 @@ paths:
 
   - name: nx-env-psu
     yang_path: /System/ch-items/psuslot-items/PsuSlot-list
-    table: CiscoEnvPower_CL
+    table: EnvPower_CL
     enabled: true
     mode: sample
     sample_interval: 300s
@@ -202,7 +202,7 @@ paths:
 
   - name: power-supply
     yang_path: /openconfig-platform:components/component/power-supply
-    table: CiscoEnvPower_CL
+    table: EnvPower_CL
     enabled: false
 
   - name: system-cpus

--- a/src/TelemetryClient/config.cisco.yaml
+++ b/src/TelemetryClient/config.cisco.yaml
@@ -32,14 +32,14 @@ paths:
   # ============================================================
   - name: interface-counters
     yang_path: /openconfig-interfaces:interfaces/interface/state/counters
-    table: CiscoInterfaceCounter_CL
+    table: InterfaceCounter_CL
     enabled: true
     mode: sample
     sample_interval: 60s
 
   - name: interface-status
     yang_path: /openconfig-interfaces:interfaces/interface/state
-    table: CiscoInterfaceStatus_CL
+    table: InterfaceStatus_CL
     enabled: true
     mode: sample
     sample_interval: 60s
@@ -47,14 +47,14 @@ paths:
 
   - name: system-state
     yang_path: /openconfig-system:system/state
-    table: CiscoSystemUptime_CL
+    table: SystemUptime_CL
     enabled: true
     mode: sample
     sample_interval: 300s
 
   - name: platform-inventory
     yang_path: /openconfig-platform:components/component
-    table: CiscoInventory_CL
+    table: Inventory_CL
     enabled: true
     mode: sample
     sample_interval: 300s
@@ -64,7 +64,7 @@ paths:
   # ============================================================
   - name: if-ethernet
     yang_path: /openconfig-if-ethernet:interfaces/interface/ethernet/state
-    table: CiscoInterfaceEthernet_CL
+    table: InterfaceEthernet_CL
     enabled: true
     mode: sample
     sample_interval: 60s
@@ -72,14 +72,14 @@ paths:
 
   - name: bgp-global
     yang_path: /openconfig-network-instance:network-instances/network-instance/protocols/protocol/bgp/global/state
-    table: CiscoBgpGlobal_CL
+    table: BgpGlobal_CL
     enabled: true
     mode: sample
     sample_interval: 300s
 
   - name: transceiver-channel
     yang_path: /openconfig-platform:components/component/transceiver/physical-channels
-    table: CiscoTransceiverDom_CL
+    table: TransceiverDom_CL
     enabled: true
     mode: sample
     sample_interval: 60s
@@ -90,30 +90,30 @@ paths:
   # ============================================================
   - name: nx-transceiver
     yang_path: /System/intf-items/phys-items/PhysIf-list/phys-items
-    table: CiscoTransceiver_CL
+    table: Transceiver_CL
     enabled: true
     mode: sample
     sample_interval: 60s
 
   - name: nx-arp
     yang_path: /System/arp-items/inst-items/dom-items/Dom-list/db-items/Db-list/adj-items/AdjEp-list
-    table: CiscoIpArp_CL
+    table: ArpEntry_CL
     enabled: true
     mode: sample
     sample_interval: 300s
 
   - name: nx-bgp-peers
     yang_path: /System/bgp-items/inst-items/dom-items/Dom-list/peer-items/Peer-list
-    table: CiscoBgpSummary_CL
+    table: BgpNeighbor_CL
     enabled: true
     mode: sample
     sample_interval: 300s
     # NOTE: vrf_local_as is not available at the Peer-list level in NX-OS YANG.
-    # It is provided in the CiscoBgpGlobal_CL table (from bgp-global OC path).
+    # It is provided in the BgpGlobal_CL table (from bgp-global OC path).
 
   - name: nx-env-sensor
     yang_path: /System/ch-items/supslot-items/SupCSlot-list/sup-items/sensor-items
-    table: CiscoEnvTemp_CL
+    table: EnvTemperature_CL
     enabled: true
     mode: sample
     sample_interval: 300s
@@ -127,21 +127,21 @@ paths:
 
   - name: nx-sys-cpu
     yang_path: /System/procsys-items/syscpusummary-items
-    table: CiscoSystemResources_CL
+    table: SystemResources_CL
     enabled: true
     mode: sample
     sample_interval: 300s
 
   - name: nx-sys-memory
     yang_path: /System/procsys-items/sysmem-items
-    table: CiscoSystemResources_CL
+    table: SystemResources_CL
     enabled: true
     mode: sample
     sample_interval: 300s
 
   - name: nx-sys-load
     yang_path: /System/procsys-items/sysload-items
-    table: CiscoSystemResources_CL
+    table: SystemResources_CL
     enabled: true
     mode: sample
     sample_interval: 300s
@@ -155,7 +155,7 @@ paths:
 
   - name: nx-mac-table
     yang_path: /System/mac-items
-    table: CiscoMacAddress_CL
+    table: MacTable_CL
     enabled: true
     mode: sample
     sample_interval: 300s
@@ -176,7 +176,7 @@ paths:
 
   - name: nx-lldp
     yang_path: /System/lldp-items/inst-items/if-items/If-list
-    table: CiscoLldpNeighbor_CL
+    table: LldpNeighbor_CL
     enabled: true
     mode: sample
     sample_interval: 300s
@@ -187,17 +187,17 @@ paths:
   # ============================================================
   - name: bgp-neighbors
     yang_path: /openconfig-network-instance:network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state
-    table: CiscoBgpSummary_CL
+    table: BgpNeighbor_CL
     enabled: false
 
   - name: lldp-neighbors
     yang_path: /openconfig-lldp:lldp/interfaces/interface/neighbors
-    table: CiscoLldpNeighbor_CL
+    table: LldpNeighbor_CL
     enabled: false
 
   - name: temperature
     yang_path: /openconfig-platform:components/component/state/temperature
-    table: CiscoEnvTemp_CL
+    table: EnvTemperature_CL
     enabled: false
 
   - name: power-supply
@@ -207,25 +207,25 @@ paths:
 
   - name: system-cpus
     yang_path: /openconfig-system:system/cpus
-    table: CiscoSystemResources_CL
+    table: SystemResources_CL
     enabled: false
 
   - name: system-memory
     yang_path: /openconfig-system:system/memory
-    table: CiscoSystemResources_CL
+    table: SystemResources_CL
     enabled: false
 
   - name: arp-table
     yang_path: /openconfig-if-ip:interfaces/interface/subinterfaces/subinterface/ipv4/neighbors
-    table: CiscoIpArp_CL
+    table: ArpEntry_CL
     enabled: false
 
   - name: mac-table
     yang_path: /openconfig-network-instance:network-instances/network-instance/fdb/mac-table
-    table: CiscoMacAddress_CL
+    table: MacTable_CL
     enabled: false
 
   - name: transceiver
     yang_path: /openconfig-platform:components/component/transceiver
-    table: CiscoTransceiver_CL
+    table: Transceiver_CL
     enabled: false

--- a/src/TelemetryClient/config.cisco.yaml
+++ b/src/TelemetryClient/config.cisco.yaml
@@ -125,6 +125,13 @@ paths:
     mode: sample
     sample_interval: 300s
 
+  - name: nx-fan
+    yang_path: /System/ch-items/ftslot-items/FtSlot-list
+    table: EnvFan_CL
+    enabled: true
+    mode: sample
+    sample_interval: 300s
+
   - name: nx-sys-cpu
     yang_path: /System/procsys-items/syscpusummary-items
     table: SystemResources_CL

--- a/src/TelemetryClient/config.sonic.yaml
+++ b/src/TelemetryClient/config.sonic.yaml
@@ -180,7 +180,7 @@ paths:
 
   - name: sonic-fan
     yang_path: /sonic-platform:sonic-platform
-    table: SonicFan_CL
+    table: EnvFan_CL
     enabled: true
     mode: sample
     sample_interval: 300s

--- a/src/TelemetryClient/config.sonic.yaml
+++ b/src/TelemetryClient/config.sonic.yaml
@@ -173,7 +173,7 @@ paths:
 
   - name: sonic-psu
     yang_path: /sonic-platform:sonic-platform
-    table: SonicEnvPower_CL
+    table: EnvPower_CL
     enabled: true
     mode: sample
     sample_interval: 300s

--- a/src/TelemetryClient/config.sonic.yaml
+++ b/src/TelemetryClient/config.sonic.yaml
@@ -49,7 +49,7 @@ paths:
   # ============================================================
   - name: interface-counters
     yang_path: /openconfig-interfaces:interfaces/interface/state/counters
-    table: SonicInterfaceCounter_CL
+    table: InterfaceCounter_CL
     enabled: true
     mode: sample
     sample_interval: 60s
@@ -57,7 +57,7 @@ paths:
 
   - name: interface-status
     yang_path: /openconfig-interfaces:interfaces/interface/state
-    table: SonicInterfaceStatus_CL
+    table: InterfaceStatus_CL
     enabled: true
     mode: sample
     sample_interval: 60s
@@ -65,7 +65,7 @@ paths:
 
   - name: if-ethernet
     yang_path: /openconfig-if-ethernet:interfaces/interface/ethernet/state
-    table: SonicInterfaceEthernet_CL
+    table: InterfaceEthernet_CL
     enabled: true
     mode: sample
     sample_interval: 60s
@@ -75,7 +75,7 @@ paths:
   # ============================================================
   - name: system-state
     yang_path: /openconfig-system:system/state
-    table: SonicSystemUptime_CL
+    table: SystemUptime_CL
     enabled: true
     mode: sample
     sample_interval: 300s
@@ -83,14 +83,14 @@ paths:
 
   - name: system-cpus
     yang_path: /openconfig-system:system/cpus
-    table: SonicSystemResources_CL
+    table: SystemResources_CL
     enabled: true
     mode: sample
     sample_interval: 300s
 
   - name: system-memory
     yang_path: /openconfig-system:system/memory
-    table: SonicSystemResources_CL
+    table: SystemResources_CL
     enabled: true
     mode: sample
     sample_interval: 300s
@@ -102,7 +102,7 @@ paths:
   # ============================================================
   - name: platform-inventory
     yang_path: /openconfig-platform:components/component
-    table: SonicInventory_CL
+    table: Inventory_CL
     enabled: true
     mode: sample
     sample_interval: 300s
@@ -116,14 +116,14 @@ paths:
   # ============================================================
   - name: bgp-neighbors
     yang_path: /openconfig-network-instance:network-instances/network-instance[name={network_instance}]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors
-    table: SonicBgpSummary_CL
+    table: BgpNeighbor_CL
     enabled: true
     mode: sample
     sample_interval: 300s
 
   - name: bgp-global
     yang_path: /openconfig-network-instance:network-instances/network-instance[name={network_instance}]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global
-    table: SonicBgpGlobal_CL
+    table: BgpGlobal_CL
     enabled: true
     mode: sample
     sample_interval: 300s
@@ -135,7 +135,7 @@ paths:
   # ============================================================
   - name: lldp-neighbors
     yang_path: /openconfig-lldp:lldp/interfaces/interface/neighbors
-    table: SonicLldpNeighbor_CL
+    table: LldpNeighbor_CL
     enabled: true
     mode: sample
     sample_interval: 300s
@@ -145,7 +145,7 @@ paths:
   # ============================================================
   - name: arp-table
     yang_path: /openconfig-if-ip:interfaces/interface/subinterfaces/subinterface/ipv4/neighbors
-    table: SonicArpEntry_CL
+    table: ArpEntry_CL
     enabled: true
     mode: sample
     sample_interval: 300s
@@ -155,18 +155,32 @@ paths:
   # ============================================================
   - name: mac-table
     yang_path: /openconfig-network-instance:network-instances/network-instance[name={network_instance}]/fdb/mac-table
-    table: SonicMacTable_CL
+    table: MacTable_CL
     enabled: true
     mode: sample
     sample_interval: 300s
 
   # ============================================================
-  # SONiC native YANG — sonic-platform returns ALL temperature,
-  # PSU, and fan data in a single query. No component keys needed.
+  # SONiC native YANG — sonic-platform contains temperature,
+  # PSU, and fan data. Split into 3 paths for separate tables.
   # ============================================================
-  - name: sonic-platform
+  - name: sonic-temperature
     yang_path: /sonic-platform:sonic-platform
-    table: SonicPlatform_CL
+    table: EnvTemperature_CL
+    enabled: true
+    mode: sample
+    sample_interval: 300s
+
+  - name: sonic-psu
+    yang_path: /sonic-platform:sonic-platform
+    table: SonicEnvPower_CL
+    enabled: true
+    mode: sample
+    sample_interval: 300s
+
+  - name: sonic-fan
+    yang_path: /sonic-platform:sonic-platform
+    table: SonicFan_CL
     enabled: true
     mode: sample
     sample_interval: 300s
@@ -189,7 +203,7 @@ paths:
   # ============================================================
   - name: temperature
     yang_path: /openconfig-platform:components/component[name=TEMP 1]/state/temperature
-    table: SonicEnvironmentTemperature_CL
+    table: EnvTemperature_CL
     enabled: false
     mode: sample
     sample_interval: 300s
@@ -201,7 +215,7 @@ paths:
   # ============================================================
   - name: power-supply
     yang_path: /openconfig-platform:components/component[name=PSU 1]/power-supply
-    table: SonicEnvironmentPower_CL
+    table: EnvPower_CL
     enabled: false
     mode: sample
     sample_interval: 300s
@@ -213,14 +227,14 @@ paths:
   # ============================================================
   - name: transceiver
     yang_path: /openconfig-platform:components/component/transceiver
-    table: SonicTransceiver_CL
+    table: Transceiver_CL
     enabled: false
     mode: sample
     sample_interval: 60s
 
   - name: transceiver-channel
     yang_path: /openconfig-platform:components/component/transceiver/physical-channels
-    table: SonicTransceiverDom_CL
+    table: TransceiverDom_CL
     enabled: false
     mode: sample
     sample_interval: 60s

--- a/src/TelemetryClient/internal/collector/collector.go
+++ b/src/TelemetryClient/internal/collector/collector.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"gnmi-collector/internal/azure"
@@ -316,11 +315,6 @@ func (c *Collector) fetchAndTransform(pathCfg config.PathConfig) ([]transform.Co
 		return nil, nil
 	}
 
-	// Apply vendor-specific data_type prefix from config.
-	// Transformers always produce "cisco_nexus_*" data types internally;
-	// this replaces the prefix for other vendors (e.g., "sonic_*").
-	applyDataTypePrefix(entries, c.cfg.DataTypePrefix())
-
 	return entries, nil
 }
 
@@ -364,20 +358,3 @@ func (c *Collector) writeTransformed(table string, entries []transform.CommonFie
 	return os.WriteFile(path, data, 0644)
 }
 
-// applyDataTypePrefix replaces the default "cisco_nexus_" prefix in data_type
-// fields with the configured vendor prefix. This allows the same transformer
-// code to produce vendor-appropriate output (e.g., "sonic_interface_counters").
-// If the configured prefix is already "cisco_nexus", this is a no-op.
-func applyDataTypePrefix(entries []transform.CommonFields, prefix string) {
-	const defaultPrefix = "cisco_nexus"
-	if prefix == defaultPrefix {
-		return
-	}
-	for i := range entries {
-		dt := entries[i].DataType
-		if strings.HasPrefix(dt, defaultPrefix+"_") {
-			category := dt[len(defaultPrefix)+1:]
-			entries[i].DataType = prefix + "_" + category
-		}
-	}
-}

--- a/src/TelemetryClient/internal/collector/collector.go
+++ b/src/TelemetryClient/internal/collector/collector.go
@@ -125,13 +125,7 @@ func (c *Collector) RunOnce() error {
 		if c.logger != nil {
 			batch := make([]map[string]interface{}, 0, len(te.entries))
 			for _, e := range te.entries {
-				raw, _ := json.Marshal(e)
-				var m map[string]interface{}
-				if err := json.Unmarshal(raw, &m); err != nil {
-					log.Printf("WARN: unmarshal entry for %s: %v", te.table, err)
-					continue
-				}
-				batch = append(batch, m)
+				batch = append(batch, flattenEntry(e))
 			}
 			if err := c.logger.Send(te.table, batch); err != nil {
 				log.Printf("ERROR: send %s: %v", te.table, err)
@@ -340,13 +334,7 @@ func (c *Collector) writeTransformed(table string, entries []transform.CommonFie
 
 	batch := make([]map[string]interface{}, 0, len(entries))
 	for _, e := range entries {
-		raw, _ := json.Marshal(e)
-		var m map[string]interface{}
-		if err := json.Unmarshal(raw, &m); err != nil {
-			log.Printf("WARN: unmarshal entry for %s: %v", table, err)
-			continue
-		}
-		batch = append(batch, m)
+		batch = append(batch, flattenEntry(e))
 	}
 
 	data, err := json.Marshal(batch)
@@ -356,5 +344,24 @@ func (c *Collector) writeTransformed(table string, entries []transform.CommonFie
 
 	path := filepath.Join(c.outputDir, table+".json")
 	return os.WriteFile(path, data, 0644)
+}
+
+// flattenEntry converts a CommonFields into a flat map suitable for
+// Azure Log Analytics ingestion. The Message map fields are promoted
+// to the top level so that LA does not prefix them with "message_".
+func flattenEntry(e transform.CommonFields) map[string]interface{} {
+	flat := map[string]interface{}{
+		"data_type": e.DataType,
+		"timestamp": e.Timestamp,
+		"date":      e.Date,
+	}
+	if msg, ok := e.Message.(map[string]interface{}); ok {
+		for k, v := range msg {
+			flat[k] = v
+		}
+	} else if e.Message != nil {
+		flat["message"] = e.Message
+	}
+	return flat
 }
 

--- a/src/TelemetryClient/internal/collector/collector_test.go
+++ b/src/TelemetryClient/internal/collector/collector_test.go
@@ -5,80 +5,20 @@ import (
 	"testing"
 )
 
-func TestApplyDataTypePrefix(t *testing.T) {
-	tests := []struct {
-		name     string
-		prefix   string
-		input    string
-		expected string
-	}{
-		{
-			name:     "cisco prefix is no-op",
-			prefix:   "cisco_nexus",
-			input:    "cisco_nexus_interface_counters",
-			expected: "cisco_nexus_interface_counters",
-		},
-		{
-			name:     "sonic prefix replaces cisco",
-			prefix:   "sonic",
-			input:    "cisco_nexus_interface_counters",
-			expected: "sonic_interface_counters",
-		},
-		{
-			name:     "sonic prefix for bgp_summary",
-			prefix:   "sonic",
-			input:    "cisco_nexus_bgp_summary",
-			expected: "sonic_bgp_summary",
-		},
-		{
-			name:     "sonic prefix for system_resources",
-			prefix:   "sonic",
-			input:    "cisco_nexus_system_resources",
-			expected: "sonic_system_resources",
-		},
-		{
-			name:     "unknown prefix for arbitrary vendor",
-			prefix:   "arista_eos",
-			input:    "cisco_nexus_lldp_neighbor",
-			expected: "arista_eos_lldp_neighbor",
-		},
-		{
-			name:     "no match if prefix missing",
-			prefix:   "sonic",
-			input:    "something_else",
-			expected: "something_else",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			entries := []transform.CommonFields{
-				{DataType: tt.input},
-			}
-			applyDataTypePrefix(entries, tt.prefix)
-			if entries[0].DataType != tt.expected {
-				t.Errorf("got %q, want %q", entries[0].DataType, tt.expected)
-			}
-		})
-	}
-}
-
-func TestApplyDataTypePrefixMultipleEntries(t *testing.T) {
+func TestMergeByDataType(t *testing.T) {
 	entries := []transform.CommonFields{
-		{DataType: "cisco_nexus_interface_counters"},
-		{DataType: "cisco_nexus_bgp_summary"},
-		{DataType: "cisco_nexus_system_resources"},
+		{DataType: "interface_counters", Message: map[string]interface{}{"a": 1}},
+		{DataType: "interface_counters", Message: map[string]interface{}{"b": 2}},
+		{DataType: "bgp_summary", Message: map[string]interface{}{"c": 3}},
 	}
-	applyDataTypePrefix(entries, "sonic")
-
-	expected := []string{
-		"sonic_interface_counters",
-		"sonic_bgp_summary",
-		"sonic_system_resources",
+	merged := mergeByDataType(entries)
+	if len(merged) != 2 {
+		t.Fatalf("expected 2 merged groups, got %d", len(merged))
 	}
-	for i, e := range entries {
-		if e.DataType != expected[i] {
-			t.Errorf("entries[%d].DataType = %q, want %q", i, e.DataType, expected[i])
-		}
+	if merged[0].DataType != "interface_counters" {
+		t.Errorf("first group data_type = %q, want interface_counters", merged[0].DataType)
+	}
+	if merged[1].DataType != "bgp_summary" {
+		t.Errorf("second group data_type = %q, want bgp_summary", merged[1].DataType)
 	}
 }

--- a/src/TelemetryClient/internal/collector/subscriber.go
+++ b/src/TelemetryClient/internal/collector/subscriber.go
@@ -268,9 +268,6 @@ func (c *Collector) subscribeOnce(
 				continue
 			}
 
-			// Apply vendor-specific data_type prefix (same as poll mode).
-			applyDataTypePrefix(entries, c.cfg.DataTypePrefix())
-
 			batch := batches[sp.Table]
 			batch.add(entries)
 			updateCount++

--- a/src/TelemetryClient/internal/collector/subscriber.go
+++ b/src/TelemetryClient/internal/collector/subscriber.go
@@ -532,10 +532,7 @@ func (c *Collector) flushBatch(batch *tableBatch) {
 
 	maps := make([]map[string]interface{}, 0, len(entries))
 	for _, e := range entries {
-		raw, _ := json.Marshal(e)
-		var m map[string]interface{}
-		json.Unmarshal(raw, &m)
-		maps = append(maps, m)
+		maps = append(maps, flattenEntry(e))
 	}
 
 	if err := c.logger.Send(batch.table, maps); err != nil {

--- a/src/TelemetryClient/internal/config/config.go
+++ b/src/TelemetryClient/internal/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -188,21 +187,3 @@ func (c *Config) ResolveAzureKeys() (workspaceID, primaryKey, secondaryKey strin
 	return
 }
 
-// DataTypePrefix returns the vendor-specific prefix used for data_type fields
-// in telemetry output. Derived from the configured device_type.
-// Examples: "cisco-nx-os" → "cisco_nexus", "sonic" → "sonic".
-func (c *Config) DataTypePrefix() string {
-	return DeviceTypeToPrefix(c.Azure.DeviceType)
-}
-
-// DeviceTypeToPrefix converts a device_type string to its data_type prefix.
-func DeviceTypeToPrefix(deviceType string) string {
-	switch deviceType {
-	case "cisco-nx-os":
-		return "cisco_nexus"
-	case "sonic":
-		return "sonic"
-	default:
-		return strings.ReplaceAll(deviceType, "-", "_")
-	}
-}

--- a/src/TelemetryClient/internal/config/config_test.go
+++ b/src/TelemetryClient/internal/config/config_test.go
@@ -303,40 +303,6 @@ func TestResolveAzureKeys(t *testing.T) {
 	}
 }
 
-func TestDataTypePrefix(t *testing.T) {
-	tests := []struct {
-		deviceType string
-		want       string
-	}{
-		{"cisco-nx-os", "cisco_nexus"},
-		{"sonic", "sonic"},
-		{"arista-eos", "arista_eos"},       // fallback: hyphen→underscore
-		{"juniper-junos", "juniper_junos"}, // fallback: hyphen→underscore
-	}
-	for _, tt := range tests {
-		t.Run(tt.deviceType, func(t *testing.T) {
-			cfg := &Config{Azure: AzureConfig{DeviceType: tt.deviceType}}
-			got := cfg.DataTypePrefix()
-			if got != tt.want {
-				t.Errorf("DataTypePrefix() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestDeviceTypeToPrefix(t *testing.T) {
-	if got := DeviceTypeToPrefix("cisco-nx-os"); got != "cisco_nexus" {
-		t.Errorf("got %q, want cisco_nexus", got)
-	}
-	if got := DeviceTypeToPrefix("sonic"); got != "sonic" {
-		t.Errorf("got %q, want sonic", got)
-	}
-	// Fallback for unknown types
-	if got := DeviceTypeToPrefix("some-new-vendor"); got != "some_new_vendor" {
-		t.Errorf("got %q, want some_new_vendor", got)
-	}
-}
-
 func TestValidatePathNames(t *testing.T) {
 	cfg := &Config{
 		Paths: []PathConfig{

--- a/src/TelemetryClient/internal/transform/arp.go
+++ b/src/TelemetryClient/internal/transform/arp.go
@@ -4,7 +4,7 @@ import (
 	"gnmi-collector/internal/gnmi"
 )
 
-const dataTypeArp = "cisco_nexus_arp_entry"
+const dataTypeArp = "arp_entry"
 
 func init() {
 	Register("arp-table", func() Transformer { return &ArpTransformer{} })

--- a/src/TelemetryClient/internal/transform/bgp_global.go
+++ b/src/TelemetryClient/internal/transform/bgp_global.go
@@ -4,7 +4,7 @@ import (
 	"gnmi-collector/internal/gnmi"
 )
 
-const dataTypeBgpGlobal = "cisco_nexus_bgp_global"
+const dataTypeBgpGlobal = "bgp_global"
 
 func init() {
 	Register("bgp-global", func() Transformer { return &BgpGlobalTransformer{} })

--- a/src/TelemetryClient/internal/transform/bgp_summary.go
+++ b/src/TelemetryClient/internal/transform/bgp_summary.go
@@ -7,7 +7,7 @@ import (
 	"gnmi-collector/internal/gnmi"
 )
 
-const dataTypeBgpSummary = "cisco_nexus_bgp_summary"
+const dataTypeBgpSummary = "bgp_summary"
 
 func init() {
 	Register("bgp-neighbors", func() Transformer { return &BgpSummaryTransformer{} })

--- a/src/TelemetryClient/internal/transform/common.go
+++ b/src/TelemetryClient/internal/transform/common.go
@@ -15,11 +15,10 @@ import (
 // CommonFields matches the existing parser output schema used by
 // the syslog writer and Azure logger.
 type CommonFields struct {
-	DataType    string      `json:"data_type"`
-	Timestamp   string      `json:"timestamp"`
-	TimestampNs int64       `json:"timestamp_ns"` // Nanosecond-precision device timestamp for Kusto ordering
-	Date        string      `json:"date"`
-	Message     interface{} `json:"message"`
+	DataType  string      `json:"data_type"`
+	Timestamp string      `json:"timestamp"` // RFC3339Nano — Log Analytics auto-types as datetime (_t)
+	Date      string      `json:"date"`
+	Message   interface{} `json:"message"`
 }
 
 // NewCommonFields creates a CommonFields entry using the gNMI notification
@@ -33,11 +32,10 @@ func NewCommonFields(dataType string, message interface{}, gnmiTimestampNs int64
 		ts = time.Now()
 	}
 	return CommonFields{
-		DataType:    dataType,
-		TimestampNs: ts.UnixNano(),
-		Timestamp:   ts.Format(time.RFC3339Nano),
-		Date:        ts.Format("2006-01-02"),
-		Message:     message,
+		DataType:  dataType,
+		Timestamp: ts.Format(time.RFC3339Nano),
+		Date:      ts.Format("2006-01-02"),
+		Message:   message,
 	}
 }
 

--- a/src/TelemetryClient/internal/transform/environment.go
+++ b/src/TelemetryClient/internal/transform/environment.go
@@ -7,7 +7,7 @@ import (
 	"gnmi-collector/internal/gnmi"
 )
 
-const dataTypeEnvTemp = "cisco_nexus_environment_temperature"
+const dataTypeEnvTemp = "environment_temperature"
 
 func init() {
 	Register("temperature", func() Transformer { return &EnvironmentTempTransformer{} })
@@ -83,7 +83,7 @@ func deriveTempStatus(alarm bool) string {
 	return "Ok"
 }
 
-const dataTypeEnvPower = "cisco_nexus_environment_power"
+const dataTypeEnvPower = "environment_power"
 
 type EnvironmentPowerTransformer struct{}
 

--- a/src/TelemetryClient/internal/transform/environment.go
+++ b/src/TelemetryClient/internal/transform/environment.go
@@ -1,17 +1,17 @@
 package transform
 
 import (
-	"fmt"
-	"strings"
+"fmt"
+"strings"
 
-	"gnmi-collector/internal/gnmi"
+"gnmi-collector/internal/gnmi"
 )
 
 const dataTypeEnvTemp = "environment_temperature"
 
 func init() {
-	Register("temperature", func() Transformer { return &EnvironmentTempTransformer{} })
-	Register("power-supply", func() Transformer { return &EnvironmentPowerTransformer{} })
+Register("temperature", func() Transformer { return &EnvironmentTempTransformer{} })
+Register("power-supply", func() Transformer { return &EnvironmentPowerTransformer{} })
 }
 
 type EnvironmentTempTransformer struct{}
@@ -19,68 +19,65 @@ type EnvironmentTempTransformer struct{}
 func (t *EnvironmentTempTransformer) DataType() string { return dataTypeEnvTemp }
 
 func (t *EnvironmentTempTransformer) Transform(notifications []gnmi.Notification) ([]CommonFields, error) {
-	var results []CommonFields
+var results []CommonFields
 
-	for _, n := range notifications {
-		for _, u := range n.Updates {
-			vals, ok := u.Value.(map[string]interface{})
-			if !ok {
-				continue
-			}
+for _, n := range notifications {
+for _, u := range n.Updates {
+vals, ok := u.Value.(map[string]interface{})
+if !ok {
+continue
+}
 
-			componentName := extractKey(u.Path, "name")
+componentName := extractKey(u.Path, "name")
 
-			// Derive module and sensor from component name
-			// e.g., "Sensor 27" → module "", sensor "Sensor 27"
-			// e.g., "Module1 Sensor FRONT" → module "1", sensor "FRONT"
-			module, sensor := parseComponentSensor(componentName)
+// Derive module and sensor from component name
+// e.g., "Sensor 27" -> module "", sensor "Sensor 27"
+// e.g., "Module1 Sensor FRONT" -> module "1", sensor "FRONT"
+module, sensor := parseComponentSensor(componentName)
 
-			// Temperature thresholds
-			majorThresh := GetFirstString(vals, "alarm-threshold", "critical-high")
-			minorThresh := GetFirstString(vals, "warning-threshold", "warning-high")
+msg := map[string]interface{}{
+"module":                  module,
+"sensor":                  sensor,
+"current_temp":            GetFirstString(vals, "instant", "avg", "max"),
+"high_threshold":          GetFirstString(vals, "alarm-threshold", "critical-high"),
+"critical_high_threshold": GetFirstString(vals, "critical-high", "alarm-threshold"),
+"low_threshold":           GetFirstString(vals, "warning-threshold", "warning-high"),
+"status":                  deriveTempStatus(GetBool(vals, "alarm-status")),
+}
 
-			msg := map[string]interface{}{
-				"module":          module,
-				"sensor":          sensor,
-				"current_temp":    GetFirstString(vals, "instant", "avg", "max"),
-				"major_threshold": majorThresh,
-				"minor_threshold": minorThresh,
-				"status":          deriveTempStatus(GetBool(vals, "alarm-status")),
-			}
+results = append(results, NewCommonFields(dataTypeEnvTemp, msg, n.Timestamp))
+}
+}
 
-			results = append(results, NewCommonFields(dataTypeEnvTemp, msg, n.Timestamp))
-		}
-	}
-
-	return results, nil
+return results, nil
 }
 
 func parseComponentSensor(name string) (module, sensor string) {
-	// Try to parse patterns like "Module1 Sensor FRONT"
-	lower := strings.ToLower(name)
-	if strings.Contains(lower, "module") {
-		parts := strings.Fields(name)
-		for _, p := range parts {
-			pl := strings.ToLower(p)
-			if strings.HasPrefix(pl, "module") {
-				module = strings.TrimPrefix(pl, "module")
-			}
-		}
-		// Sensor is the last word (FRONT, BACK, CPU, etc.)
-		if len(parts) > 0 {
-			sensor = parts[len(parts)-1]
-		}
-	} else {
-		sensor = name
-	}
-	return module, sensor
+// Try to parse patterns like "Module1 Sensor FRONT"
+lower := strings.ToLower(name)
+if strings.Contains(lower, "module") {
+parts := strings.Fields(name)
+for _, p := range parts {
+pl := strings.ToLower(p)
+if strings.HasPrefix(pl, "module") {
+module = strings.TrimPrefix(pl, "module")
+}
+}
+// Sensor is the last word (FRONT, BACK, CPU, etc.)
+if len(parts) > 0 {
+sensor = parts[len(parts)-1]
+}
+} else {
+sensor = name
+}
+return module, sensor
 }
 
 func deriveTempStatus(alarm bool) string {
-	if alarm {
-		return "Alert"
-	}
-	return "Ok"
+if alarm {
+return "Alert"
+}
+return "Ok"
 }
 
 const dataTypeEnvPower = "environment_power"
@@ -90,62 +87,56 @@ type EnvironmentPowerTransformer struct{}
 func (t *EnvironmentPowerTransformer) DataType() string { return dataTypeEnvPower }
 
 func (t *EnvironmentPowerTransformer) Transform(notifications []gnmi.Notification) ([]CommonFields, error) {
-	var supplies []map[string]interface{}
-	var lastTS int64
+var results []CommonFields
 
-	for _, n := range notifications {
-		lastTS = n.Timestamp
-		for _, u := range n.Updates {
-			vals, ok := u.Value.(map[string]interface{})
-			if !ok {
-				continue
-			}
+for _, n := range notifications {
+for _, u := range n.Updates {
+vals, ok := u.Value.(map[string]interface{})
+if !ok {
+continue
+}
 
-			psName := extractKey(u.Path, "name")
-			state := GetMap(vals, "state")
-			if state == nil {
-				state = vals
-			}
+psName := extractKey(u.Path, "name")
+state := GetMap(vals, "state")
+if state == nil {
+state = vals
+}
 
-			ps := map[string]interface{}{
-				"ps_number": psName,
-				"status":    derivePowerStatus(GetBool(state, "enabled")),
-				"model":     GetFirstString(state, "description", "model", "part-no"),
-			}
+msg := map[string]interface{}{
+"ps_name": psName,
+"status":  derivePowerStatus(GetBool(state, "enabled")),
+"model":   GetFirstString(state, "description", "model", "part-no"),
+}
 
-			// Decode base64-encoded float values
-			for _, field := range []struct{ src, dst string }{
-				{"capacity", "total_capacity"},
-				{"input-current", "iin"},
-				{"input-voltage", "vin"},
-				{"output-current", "iout"},
-				{"output-power", "pout"},
-				{"output-voltage", "vout"},
-			} {
-				raw := GetString(state, field.src)
-				if raw != "" {
-					if f, err := DecodeBase64Float32(raw); err == nil {
-						ps[field.dst] = fmt.Sprintf("%.2f", f)
-					} else {
-						ps[field.dst] = raw
-					}
-				}
-			}
+// Decode base64-encoded float values
+for _, field := range []struct{ src, dst string }{
+{"capacity", "total_capacity"},
+{"input-current", "input_current"},
+{"input-voltage", "input_voltage"},
+{"output-current", "output_current"},
+{"output-power", "output_power"},
+{"output-voltage", "output_voltage"},
+} {
+raw := GetString(state, field.src)
+if raw != "" {
+if f, err := DecodeBase64Float32(raw); err == nil {
+msg[field.dst] = fmt.Sprintf("%.2f", f)
+} else {
+msg[field.dst] = raw
+}
+}
+}
 
-			supplies = append(supplies, ps)
-		}
-	}
+results = append(results, NewCommonFields(dataTypeEnvPower, msg, n.Timestamp))
+}
+}
 
-	msg := map[string]interface{}{
-		"power_supplies": supplies,
-	}
-	result := NewCommonFields(dataTypeEnvPower, msg, lastTS)
-	return []CommonFields{result}, nil
+return results, nil
 }
 
 func derivePowerStatus(enabled bool) string {
-	if enabled {
-		return "Ok"
-	}
-	return "Shutdown"
+if enabled {
+return "Ok"
+}
+return "Shutdown"
 }

--- a/src/TelemetryClient/internal/transform/interface_counters.go
+++ b/src/TelemetryClient/internal/transform/interface_counters.go
@@ -4,7 +4,7 @@ import (
 	"gnmi-collector/internal/gnmi"
 )
 
-const dataTypeInterfaceCounters = "cisco_nexus_interface_counters"
+const dataTypeInterfaceCounters = "interface_counters"
 
 func init() {
 	Register("interface-counters", func() Transformer { return &InterfaceCountersTransformer{} })

--- a/src/TelemetryClient/internal/transform/interface_ethernet.go
+++ b/src/TelemetryClient/internal/transform/interface_ethernet.go
@@ -6,7 +6,7 @@ import (
 	"gnmi-collector/internal/gnmi"
 )
 
-const dataTypeInterfaceEthernet = "cisco_nexus_interface_ethernet"
+const dataTypeInterfaceEthernet = "interface_ethernet"
 
 func init() {
 	Register("if-ethernet", func() Transformer { return &InterfaceEthernetTransformer{} })

--- a/src/TelemetryClient/internal/transform/interface_status.go
+++ b/src/TelemetryClient/internal/transform/interface_status.go
@@ -4,7 +4,7 @@ import (
 	"gnmi-collector/internal/gnmi"
 )
 
-const dataTypeInterfaceStatus = "cisco_nexus_interface_status"
+const dataTypeInterfaceStatus = "interface_status"
 
 func init() {
 	Register("interface-status", func() Transformer { return &InterfaceStatusTransformer{} })

--- a/src/TelemetryClient/internal/transform/inventory.go
+++ b/src/TelemetryClient/internal/transform/inventory.go
@@ -4,7 +4,7 @@ import (
 	"gnmi-collector/internal/gnmi"
 )
 
-const dataTypeInventory = "cisco_nexus_inventory"
+const dataTypeInventory = "inventory"
 
 func init() {
 	Register("platform-inventory", func() Transformer { return &InventoryTransformer{} })

--- a/src/TelemetryClient/internal/transform/lldp_neighbor.go
+++ b/src/TelemetryClient/internal/transform/lldp_neighbor.go
@@ -4,7 +4,7 @@ import (
 	"gnmi-collector/internal/gnmi"
 )
 
-const dataTypeLldpNeighbor = "cisco_nexus_lldp_neighbor"
+const dataTypeLldpNeighbor = "lldp_neighbor"
 
 func init() {
 	Register("lldp-neighbors", func() Transformer { return &LldpNeighborTransformer{} })

--- a/src/TelemetryClient/internal/transform/mac_address.go
+++ b/src/TelemetryClient/internal/transform/mac_address.go
@@ -4,7 +4,7 @@ import (
 	"gnmi-collector/internal/gnmi"
 )
 
-const dataTypeMacTable = "cisco_nexus_mac_table"
+const dataTypeMacTable = "mac_table"
 
 func init() {
 	Register("mac-table", func() Transformer { return &MacAddressTransformer{} })

--- a/src/TelemetryClient/internal/transform/mac_address.go
+++ b/src/TelemetryClient/internal/transform/mac_address.go
@@ -57,8 +57,8 @@ func (t *MacAddressTransformer) Transform(notifications []gnmi.Notification) ([]
 					"type":        GetString(state, "entry-type"),
 					"age":         GetString(state, "age"),
 					"port":        port,
-					"secure":      GetString(state, "secure"),
-					"ntfy":        GetString(state, "ntfy"),
+					"secure":      GetBool(state, "secure"),
+					"ntfy":        GetBool(state, "ntfy"),
 				}
 
 				results = append(results, NewCommonFields(dataTypeMacTable, msg, n.Timestamp))

--- a/src/TelemetryClient/internal/transform/native_environment.go
+++ b/src/TelemetryClient/internal/transform/native_environment.go
@@ -11,6 +11,7 @@ type NativeEnvTempTransformer struct{}
 func init() {
 Register("nx-env-sensor", func() Transformer { return &NativeEnvTempTransformer{} })
 Register("nx-env-psu", func() Transformer { return &NativeEnvPowerTransformer{} })
+Register("nx-fan", func() Transformer { return &NativeEnvFanTransformer{} })
 }
 
 func (t *NativeEnvTempTransformer) DataType() string { return dataTypeEnvTemp }
@@ -67,6 +68,76 @@ return map[string]interface{}{
 // NativeEnvPowerTransformer handles native Cisco NX-OS YANG PSU data
 // from /System/ch-items/psuslot-items/PsuSlot-list.
 type NativeEnvPowerTransformer struct{}
+
+// NativeEnvFanTransformer handles native Cisco NX-OS YANG fan data
+// from /System/ch-items/ftslot-items/FtSlot-list.
+type NativeEnvFanTransformer struct{}
+
+func (t *NativeEnvFanTransformer) DataType() string { return "fan" }
+
+func (t *NativeEnvFanTransformer) Transform(notifications []gnmi.Notification) ([]CommonFields, error) {
+var results []CommonFields
+
+for _, n := range notifications {
+for _, u := range n.Updates {
+entries := AsMapSlice(u.Value)
+if entries == nil {
+continue
+}
+
+for _, vals := range entries {
+id := GetString(vals, "id")
+if id == "" {
+id = extractKey(u.Path, "id")
+}
+
+// NX-OS structure: FtSlot-list -> ft-items -> fan-items -> Fan-list
+ft := GetMap(vals, "ft-items")
+if ft == nil {
+// Try direct fan-items at slot level
+ft = vals
+}
+
+fanList := GetSlice(ft, "Fan-list")
+if fanList == nil {
+// Flat structure: extract from ft-items directly
+msg := map[string]interface{}{
+"name":      id,
+"model":     GetString(ft, "model"),
+"direction": GetString(ft, "dir"),
+"status":    GetString(ft, "operSt"),
+"serial":    GetString(ft, "ser"),
+}
+results = append(results, NewCommonFields("fan", msg, n.Timestamp))
+continue
+}
+
+// Nested structure: iterate over Fan-list entries
+for _, raw := range fanList {
+fan, ok := raw.(map[string]interface{})
+if !ok {
+continue
+}
+fanID := GetString(fan, "id")
+name := id
+if fanID != "" {
+name = id + "/" + fanID
+}
+msg := map[string]interface{}{
+"name":      name,
+"model":     GetString(ft, "model"),
+"direction": GetString(fan, "dir"),
+"status":    GetString(fan, "operSt"),
+"serial":    GetString(ft, "ser"),
+}
+results = append(results, NewCommonFields("fan", msg, n.Timestamp))
+}
+}
+}
+}
+
+return results, nil
+}
 
 func (t *NativeEnvPowerTransformer) DataType() string { return dataTypeEnvPower }
 

--- a/src/TelemetryClient/internal/transform/native_environment.go
+++ b/src/TelemetryClient/internal/transform/native_environment.go
@@ -1,7 +1,7 @@
 package transform
 
 import (
-	"gnmi-collector/internal/gnmi"
+"gnmi-collector/internal/gnmi"
 )
 
 // NativeEnvTempTransformer handles native Cisco NX-OS YANG temperature sensor data
@@ -9,59 +9,59 @@ import (
 type NativeEnvTempTransformer struct{}
 
 func init() {
-	Register("nx-env-sensor", func() Transformer { return &NativeEnvTempTransformer{} })
-	Register("nx-env-psu", func() Transformer { return &NativeEnvPowerTransformer{} })
+Register("nx-env-sensor", func() Transformer { return &NativeEnvTempTransformer{} })
+Register("nx-env-psu", func() Transformer { return &NativeEnvPowerTransformer{} })
 }
 
 func (t *NativeEnvTempTransformer) DataType() string { return dataTypeEnvTemp }
 
 func (t *NativeEnvTempTransformer) Transform(notifications []gnmi.Notification) ([]CommonFields, error) {
-	var results []CommonFields
+var results []CommonFields
 
-	for _, n := range notifications {
-		for _, u := range n.Updates {
-			vals, ok := u.Value.(map[string]interface{})
-			if !ok {
-				continue
-			}
+for _, n := range notifications {
+for _, u := range n.Updates {
+vals, ok := u.Value.(map[string]interface{})
+if !ok {
+continue
+}
 
-			module := extractKey(u.Path, "id")
+module := extractKey(u.Path, "id")
 
-			sensors := GetSlice(vals, "Sensor-list")
-			if sensors == nil {
-				// Value may be a single sensor entry rather than a list.
-				msg := nativeTempMsg(module, vals)
-				if msg != nil {
-					results = append(results, NewCommonFields(dataTypeEnvTemp, msg, n.Timestamp))
-				}
-				continue
-			}
+sensors := GetSlice(vals, "Sensor-list")
+if sensors == nil {
+// Value may be a single sensor entry rather than a list.
+msg := nativeTempMsg(module, vals)
+if msg != nil {
+results = append(results, NewCommonFields(dataTypeEnvTemp, msg, n.Timestamp))
+}
+continue
+}
 
-			for _, raw := range sensors {
-				sensor, ok := raw.(map[string]interface{})
-				if !ok {
-					continue
-				}
-				msg := nativeTempMsg(module, sensor)
-				if msg != nil {
-					results = append(results, NewCommonFields(dataTypeEnvTemp, msg, n.Timestamp))
-				}
-			}
-		}
-	}
+for _, raw := range sensors {
+sensor, ok := raw.(map[string]interface{})
+if !ok {
+continue
+}
+msg := nativeTempMsg(module, sensor)
+if msg != nil {
+results = append(results, NewCommonFields(dataTypeEnvTemp, msg, n.Timestamp))
+}
+}
+}
+}
 
-	return results, nil
+return results, nil
 }
 
 func nativeTempMsg(module string, sensor map[string]interface{}) map[string]interface{} {
-	return map[string]interface{}{
-		"module":          module,
-		"sensor":          GetString(sensor, "descr"),
-		"current_temp":    GetString(sensor, "tempValue"),
-		"major_threshold": GetString(sensor, "majorThresh"),
-		"minor_threshold": GetString(sensor, "minorThresh"),
-		"status":          GetString(sensor, "operSt"),
-	}
+return map[string]interface{}{
+"module":          module,
+"sensor":          GetString(sensor, "descr"),
+"current_temp":    GetString(sensor, "tempValue"),
+"high_threshold":  GetString(sensor, "majorThresh"),
+"low_threshold":   GetString(sensor, "minorThresh"),
+"status":          GetString(sensor, "operSt"),
+}
 }
 
 // NativeEnvPowerTransformer handles native Cisco NX-OS YANG PSU data
@@ -71,58 +71,52 @@ type NativeEnvPowerTransformer struct{}
 func (t *NativeEnvPowerTransformer) DataType() string { return dataTypeEnvPower }
 
 func (t *NativeEnvPowerTransformer) Transform(notifications []gnmi.Notification) ([]CommonFields, error) {
-	var supplies []map[string]interface{}
-	var lastTS int64
+var results []CommonFields
 
-	for _, n := range notifications {
-		lastTS = n.Timestamp
-		for _, u := range n.Updates {
-			// NX-OS returns arrays for YANG list nodes (PsuSlot-list)
-			entries := AsMapSlice(u.Value)
-			if entries == nil {
-				continue
-			}
+for _, n := range notifications {
+for _, u := range n.Updates {
+// NX-OS returns arrays for YANG list nodes (PsuSlot-list)
+entries := AsMapSlice(u.Value)
+if entries == nil {
+continue
+}
 
-			for _, vals := range entries {
-				psu := GetMap(vals, "psu-items")
-				if psu == nil {
-					continue
-				}
+for _, vals := range entries {
+psu := GetMap(vals, "psu-items")
+if psu == nil {
+continue
+}
 
-				psNumber := GetString(vals, "id")
-				if psNumber == "" {
-					psNumber = extractKey(u.Path, "id")
-				}
+psNumber := GetString(vals, "id")
+if psNumber == "" {
+psNumber = extractKey(u.Path, "id")
+}
 
-				ps := map[string]interface{}{
-					"ps_number":      psNumber,
-					"model":          GetString(psu, "model"),
-					"serial":         GetString(psu, "ser"),
-					"vendor":         GetString(psu, "vendor"),
-					"status":         GetString(psu, "operSt"),
-					"total_capacity": GetString(psu, "cap"),
-					"vin":            GetString(psu, "vIn"),
-					"iin":            GetString(psu, "iIn"),
-					"vout":           GetString(psu, "vOut"),
-					"iout":           GetString(psu, "iOut"),
-					"pout":           GetString(psu, "pOut"),
-					"actual_input":   GetString(psu, "pIn"),
-					"actual_output":  GetString(psu, "pOut"),
-					"cord_status":    GetString(psu, "typeCordConnected"),
-					"software_alarm": GetBool(psu, "softwareAlarm"),
-					"hardware_alarm": GetString(psu, "hardwareAlarm"),
-					"fan_direction":  GetString(psu, "fanDirection"),
-					"fan_status":     GetString(psu, "fanOpSt"),
-				}
+msg := map[string]interface{}{
+"ps_name":         psNumber,
+"model":           GetString(psu, "model"),
+"serial":          GetString(psu, "ser"),
+"vendor":          GetString(psu, "vendor"),
+"status":          GetString(psu, "operSt"),
+"total_capacity":  GetString(psu, "cap"),
+"input_voltage":   GetString(psu, "vIn"),
+"input_current":   GetString(psu, "iIn"),
+"output_voltage":  GetString(psu, "vOut"),
+"output_current":  GetString(psu, "iOut"),
+"output_power":    GetString(psu, "pOut"),
+"actual_input":    GetString(psu, "pIn"),
+"actual_output":   GetString(psu, "pOut"),
+"cord_status":     GetString(psu, "typeCordConnected"),
+"software_alarm":  GetBool(psu, "softwareAlarm"),
+"hardware_alarm":  GetString(psu, "hardwareAlarm"),
+"fan_direction":   GetString(psu, "fanDirection"),
+"fan_status":      GetString(psu, "fanOpSt"),
+}
 
-				supplies = append(supplies, ps)
-			}
-		}
-	}
+results = append(results, NewCommonFields(dataTypeEnvPower, msg, n.Timestamp))
+}
+}
+}
 
-	msg := map[string]interface{}{
-		"power_supplies": supplies,
-	}
-	result := NewCommonFields(dataTypeEnvPower, msg, lastTS)
-	return []CommonFields{result}, nil
+return results, nil
 }

--- a/src/TelemetryClient/internal/transform/native_interface_errors.go
+++ b/src/TelemetryClient/internal/transform/native_interface_errors.go
@@ -4,7 +4,7 @@ import (
 	"gnmi-collector/internal/gnmi"
 )
 
-const dataTypeInterfaceErrors = "cisco_nexus_interface_error_counters"
+const dataTypeInterfaceErrors = "interface_error_counters"
 
 // NativeInterfaceErrorsTransformer handles native Cisco NX-OS YANG data
 // from /System/intf-items/phys-items/PhysIf-list/dbgEtherStats-items.

--- a/src/TelemetryClient/internal/transform/native_lldp.go
+++ b/src/TelemetryClient/internal/transform/native_lldp.go
@@ -7,8 +7,6 @@ import (
 	"gnmi-collector/internal/gnmi"
 )
 
-const dataTypeNativeLldp = "cisco_nexus_lldp_neighbor"
-
 func init() {
 	Register("nx-lldp", func() Transformer { return &NativeLldpTransformer{} })
 }
@@ -16,7 +14,7 @@ func init() {
 type NativeLldpTransformer struct{}
 
 func (t *NativeLldpTransformer) DataType() string {
-	return dataTypeNativeLldp
+	return dataTypeLldpNeighbor
 }
 
 func (t *NativeLldpTransformer) Transform(notifications []gnmi.Notification) ([]CommonFields, error) {
@@ -90,7 +88,7 @@ func (t *NativeLldpTransformer) Transform(notifications []gnmi.Notification) ([]
 						"enabled_capabilities":        enCaps,
 					}
 
-					results = append(results, NewCommonFields(dataTypeNativeLldp, msg, n.Timestamp))
+					results = append(results, NewCommonFields(dataTypeLldpNeighbor, msg, n.Timestamp))
 				}
 			}
 		}

--- a/src/TelemetryClient/internal/transform/native_mac.go
+++ b/src/TelemetryClient/internal/transform/native_mac.go
@@ -6,8 +6,6 @@ import (
 	"gnmi-collector/internal/gnmi"
 )
 
-const dataTypeNativeMac = "cisco_nexus_mac_table"
-
 func init() {
 	Register("nx-mac-table", func() Transformer { return &NativeMacTransformer{} })
 }
@@ -15,7 +13,7 @@ func init() {
 type NativeMacTransformer struct{}
 
 func (t *NativeMacTransformer) DataType() string {
-	return dataTypeNativeMac
+	return dataTypeMacTable
 }
 
 func (t *NativeMacTransformer) Transform(notifications []gnmi.Notification) ([]CommonFields, error) {
@@ -67,7 +65,7 @@ func (t *NativeMacTransformer) Transform(notifications []gnmi.Notification) ([]C
 					"routed_mac":    GetBool(entry, "routed"),
 				}
 
-				results = append(results, NewCommonFields(dataTypeNativeMac, msg, n.Timestamp))
+				results = append(results, NewCommonFields(dataTypeMacTable, msg, n.Timestamp))
 			}
 		}
 	}

--- a/src/TelemetryClient/internal/transform/native_route.go
+++ b/src/TelemetryClient/internal/transform/native_route.go
@@ -2,7 +2,7 @@ package transform
 
 import "gnmi-collector/internal/gnmi"
 
-const dataTypeRouteSummary = "cisco_nexus_route_summary"
+const dataTypeRouteSummary = "route_summary"
 
 // NativeRouteSummaryTransformer handles native Cisco NX-OS YANG route summary data
 // from /System/urib-items/table4-items/Table4-list/sum-items.

--- a/src/TelemetryClient/internal/transform/native_version.go
+++ b/src/TelemetryClient/internal/transform/native_version.go
@@ -4,7 +4,7 @@ import (
 	"gnmi-collector/internal/gnmi"
 )
 
-const dataTypeVersion = "cisco_nexus_version"
+const dataTypeVersion = "version"
 
 // NativeVersionTransformer handles native Cisco NX-OS YANG version data
 // from /System/showversion-items.

--- a/src/TelemetryClient/internal/transform/registry_test.go
+++ b/src/TelemetryClient/internal/transform/registry_test.go
@@ -42,7 +42,9 @@ func TestRegistryHasAllTransformers(t *testing.T) {
 		"nx-route-summary",
 		"nx-sys-load",
 		// SONiC native YANG transformers
-		"sonic-platform",
+		"sonic-temperature",
+		"sonic-psu",
+		"sonic-fan",
 		"sonic-device-metadata",
 	}
 	sort.Strings(expected)

--- a/src/TelemetryClient/internal/transform/registry_test.go
+++ b/src/TelemetryClient/internal/transform/registry_test.go
@@ -33,6 +33,7 @@ func TestRegistryHasAllTransformers(t *testing.T) {
 		"nx-bgp-peers",
 		"nx-env-sensor",
 		"nx-env-psu",
+		"nx-fan",
 		"nx-sys-cpu",
 		"nx-sys-memory",
 		"nx-mac-table",

--- a/src/TelemetryClient/internal/transform/sonic_device_metadata.go
+++ b/src/TelemetryClient/internal/transform/sonic_device_metadata.go
@@ -2,7 +2,7 @@ package transform
 
 import "gnmi-collector/internal/gnmi"
 
-const dataTypeSonicDeviceMetadata = "sonic_device_metadata"
+const dataTypeSonicDeviceMetadata = "device_metadata"
 
 func init() {
 	Register("sonic-device-metadata", func() Transformer { return &SonicDeviceMetadataTransformer{} })

--- a/src/TelemetryClient/internal/transform/sonic_platform.go
+++ b/src/TelemetryClient/internal/transform/sonic_platform.go
@@ -2,48 +2,60 @@ package transform
 
 import "gnmi-collector/internal/gnmi"
 
-const (
-	dataTypeSonicTemperature = "sonic_temperature"
-	dataTypeSonicPsu         = "sonic_psu"
-	dataTypeSonicFan         = "sonic_fan"
-)
-
 func init() {
-	Register("sonic-platform", func() Transformer { return &SonicPlatformTransformer{} })
+	Register("sonic-temperature", func() Transformer { return &SonicTemperatureTransformer{} })
+	Register("sonic-psu", func() Transformer { return &SonicPsuTransformer{} })
+	Register("sonic-fan", func() Transformer { return &SonicFanTransformer{} })
 }
 
-type SonicPlatformTransformer struct{}
+// SonicTemperatureTransformer extracts temperature sensor data from
+// the SONiC native sonic-platform response.
+type SonicTemperatureTransformer struct{}
 
-func (t *SonicPlatformTransformer) DataType() string { return dataTypeSonicTemperature }
+func (t *SonicTemperatureTransformer) DataType() string { return dataTypeEnvTemp }
 
-func (t *SonicPlatformTransformer) Transform(notifications []gnmi.Notification) ([]CommonFields, error) {
+func (t *SonicTemperatureTransformer) Transform(notifications []gnmi.Notification) ([]CommonFields, error) {
 	var results []CommonFields
-
 	for _, n := range notifications {
 		for _, u := range n.Updates {
 			vals, ok := u.Value.(map[string]interface{})
 			if !ok {
 				continue
 			}
-
-			// Temperature sensors
 			if tempInfo := GetMap(vals, "TEMPERATURE_INFO"); tempInfo != nil {
 				tempList := AsMapSlice(tempInfo["TEMPERATURE_INFO_LIST"])
 				for _, sensor := range tempList {
 					msg := map[string]interface{}{
-						"sensor":                 GetString(sensor, "name"),
-						"current_temp":            GetString(sensor, "temperature"),
-						"high_threshold":           GetString(sensor, "high_threshold"),
-						"critical_high_threshold":  GetString(sensor, "critical_high_threshold"),
-						"low_threshold":            GetString(sensor, "low_threshold"),
-						"warning_status":           GetString(sensor, "warning_status"),
-						"timestamp":                GetString(sensor, "timestamp"),
+						"sensor":                  GetString(sensor, "name"),
+						"current_temp":             GetString(sensor, "temperature"),
+						"high_threshold":            GetString(sensor, "high_threshold"),
+						"critical_high_threshold":   GetString(sensor, "critical_high_threshold"),
+						"low_threshold":             GetString(sensor, "low_threshold"),
+						"warning_status":            GetString(sensor, "warning_status"),
+						"timestamp":                 GetString(sensor, "timestamp"),
 					}
-					results = append(results, NewCommonFields(dataTypeSonicTemperature, msg, n.Timestamp))
+					results = append(results, NewCommonFields(dataTypeEnvTemp, msg, n.Timestamp))
 				}
 			}
+		}
+	}
+	return results, nil
+}
 
-			// PSU
+// SonicPsuTransformer extracts power supply data from the SONiC
+// native sonic-platform response.
+type SonicPsuTransformer struct{}
+
+func (t *SonicPsuTransformer) DataType() string { return "psu" }
+
+func (t *SonicPsuTransformer) Transform(notifications []gnmi.Notification) ([]CommonFields, error) {
+	var results []CommonFields
+	for _, n := range notifications {
+		for _, u := range n.Updates {
+			vals, ok := u.Value.(map[string]interface{})
+			if !ok {
+				continue
+			}
 			if psuInfo := GetMap(vals, "PSU_INFO"); psuInfo != nil {
 				psuList := AsMapSlice(psuInfo["PSU_INFO_LIST"])
 				for _, psu := range psuList {
@@ -59,11 +71,28 @@ func (t *SonicPlatformTransformer) Transform(notifications []gnmi.Notification) 
 						"output_current": GetString(psu, "output_current"),
 						"output_power":   GetString(psu, "output_power"),
 					}
-					results = append(results, NewCommonFields(dataTypeSonicPsu, msg, n.Timestamp))
+					results = append(results, NewCommonFields("psu", msg, n.Timestamp))
 				}
 			}
+		}
+	}
+	return results, nil
+}
 
-			// Fans
+// SonicFanTransformer extracts fan data from the SONiC native
+// sonic-platform response.
+type SonicFanTransformer struct{}
+
+func (t *SonicFanTransformer) DataType() string { return "fan" }
+
+func (t *SonicFanTransformer) Transform(notifications []gnmi.Notification) ([]CommonFields, error) {
+	var results []CommonFields
+	for _, n := range notifications {
+		for _, u := range n.Updates {
+			vals, ok := u.Value.(map[string]interface{})
+			if !ok {
+				continue
+			}
 			if fanInfo := GetMap(vals, "FAN_INFO"); fanInfo != nil {
 				fanList := AsMapSlice(fanInfo["FAN_INFO_LIST"])
 				for _, fan := range fanList {
@@ -76,11 +105,10 @@ func (t *SonicPlatformTransformer) Transform(notifications []gnmi.Notification) 
 						"status":      GetString(fan, "status"),
 						"drawer_name": GetString(fan, "drawer_name"),
 					}
-					results = append(results, NewCommonFields(dataTypeSonicFan, msg, n.Timestamp))
+					results = append(results, NewCommonFields("fan", msg, n.Timestamp))
 				}
 			}
 		}
 	}
-
 	return results, nil
 }

--- a/src/TelemetryClient/internal/transform/sonic_platform.go
+++ b/src/TelemetryClient/internal/transform/sonic_platform.go
@@ -3,9 +3,9 @@ package transform
 import "gnmi-collector/internal/gnmi"
 
 func init() {
-	Register("sonic-temperature", func() Transformer { return &SonicTemperatureTransformer{} })
-	Register("sonic-psu", func() Transformer { return &SonicPsuTransformer{} })
-	Register("sonic-fan", func() Transformer { return &SonicFanTransformer{} })
+Register("sonic-temperature", func() Transformer { return &SonicTemperatureTransformer{} })
+Register("sonic-psu", func() Transformer { return &SonicPsuTransformer{} })
+Register("sonic-fan", func() Transformer { return &SonicFanTransformer{} })
 }
 
 // SonicTemperatureTransformer extracts temperature sensor data from
@@ -15,68 +15,67 @@ type SonicTemperatureTransformer struct{}
 func (t *SonicTemperatureTransformer) DataType() string { return dataTypeEnvTemp }
 
 func (t *SonicTemperatureTransformer) Transform(notifications []gnmi.Notification) ([]CommonFields, error) {
-	var results []CommonFields
-	for _, n := range notifications {
-		for _, u := range n.Updates {
-			vals, ok := u.Value.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			if tempInfo := GetMap(vals, "TEMPERATURE_INFO"); tempInfo != nil {
-				tempList := AsMapSlice(tempInfo["TEMPERATURE_INFO_LIST"])
-				for _, sensor := range tempList {
-					msg := map[string]interface{}{
-						"sensor":                  GetString(sensor, "name"),
-						"current_temp":             GetString(sensor, "temperature"),
-						"high_threshold":            GetString(sensor, "high_threshold"),
-						"critical_high_threshold":   GetString(sensor, "critical_high_threshold"),
-						"low_threshold":             GetString(sensor, "low_threshold"),
-						"warning_status":            GetString(sensor, "warning_status"),
-						"timestamp":                 GetString(sensor, "timestamp"),
-					}
-					results = append(results, NewCommonFields(dataTypeEnvTemp, msg, n.Timestamp))
-				}
-			}
-		}
-	}
-	return results, nil
+var results []CommonFields
+for _, n := range notifications {
+for _, u := range n.Updates {
+vals, ok := u.Value.(map[string]interface{})
+if !ok {
+continue
+}
+if tempInfo := GetMap(vals, "TEMPERATURE_INFO"); tempInfo != nil {
+tempList := AsMapSlice(tempInfo["TEMPERATURE_INFO_LIST"])
+for _, sensor := range tempList {
+msg := map[string]interface{}{
+"sensor":                  GetString(sensor, "name"),
+"current_temp":            GetString(sensor, "temperature"),
+"high_threshold":           GetString(sensor, "high_threshold"),
+"critical_high_threshold":  GetString(sensor, "critical_high_threshold"),
+"low_threshold":            GetString(sensor, "low_threshold"),
+"status":                  GetString(sensor, "warning_status"),
+}
+results = append(results, NewCommonFields(dataTypeEnvTemp, msg, n.Timestamp))
+}
+}
+}
+}
+return results, nil
 }
 
 // SonicPsuTransformer extracts power supply data from the SONiC
 // native sonic-platform response.
 type SonicPsuTransformer struct{}
 
-func (t *SonicPsuTransformer) DataType() string { return "psu" }
+func (t *SonicPsuTransformer) DataType() string { return dataTypeEnvPower }
 
 func (t *SonicPsuTransformer) Transform(notifications []gnmi.Notification) ([]CommonFields, error) {
-	var results []CommonFields
-	for _, n := range notifications {
-		for _, u := range n.Updates {
-			vals, ok := u.Value.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			if psuInfo := GetMap(vals, "PSU_INFO"); psuInfo != nil {
-				psuList := AsMapSlice(psuInfo["PSU_INFO_LIST"])
-				for _, psu := range psuList {
-					msg := map[string]interface{}{
-						"name":           GetString(psu, "name"),
-						"status":         GetString(psu, "status"),
-						"model":          GetString(psu, "model"),
-						"serial":         GetString(psu, "serial"),
-						"temp":           GetString(psu, "temp"),
-						"input_voltage":  GetString(psu, "input_voltage"),
-						"input_current":  GetString(psu, "input_current"),
-						"output_voltage": GetString(psu, "output_voltage"),
-						"output_current": GetString(psu, "output_current"),
-						"output_power":   GetString(psu, "output_power"),
-					}
-					results = append(results, NewCommonFields("psu", msg, n.Timestamp))
-				}
-			}
-		}
-	}
-	return results, nil
+var results []CommonFields
+for _, n := range notifications {
+for _, u := range n.Updates {
+vals, ok := u.Value.(map[string]interface{})
+if !ok {
+continue
+}
+if psuInfo := GetMap(vals, "PSU_INFO"); psuInfo != nil {
+psuList := AsMapSlice(psuInfo["PSU_INFO_LIST"])
+for _, psu := range psuList {
+msg := map[string]interface{}{
+"ps_name":        GetString(psu, "name"),
+"status":         GetString(psu, "status"),
+"model":          GetString(psu, "model"),
+"serial":         GetString(psu, "serial"),
+"temp":           GetString(psu, "temp"),
+"input_voltage":  GetString(psu, "input_voltage"),
+"input_current":  GetString(psu, "input_current"),
+"output_voltage": GetString(psu, "output_voltage"),
+"output_current": GetString(psu, "output_current"),
+"output_power":   GetString(psu, "output_power"),
+}
+results = append(results, NewCommonFields(dataTypeEnvPower, msg, n.Timestamp))
+}
+}
+}
+}
+return results, nil
 }
 
 // SonicFanTransformer extracts fan data from the SONiC native
@@ -86,29 +85,29 @@ type SonicFanTransformer struct{}
 func (t *SonicFanTransformer) DataType() string { return "fan" }
 
 func (t *SonicFanTransformer) Transform(notifications []gnmi.Notification) ([]CommonFields, error) {
-	var results []CommonFields
-	for _, n := range notifications {
-		for _, u := range n.Updates {
-			vals, ok := u.Value.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			if fanInfo := GetMap(vals, "FAN_INFO"); fanInfo != nil {
-				fanList := AsMapSlice(fanInfo["FAN_INFO_LIST"])
-				for _, fan := range fanList {
-					msg := map[string]interface{}{
-						"name":        GetString(fan, "name"),
-						"speed":       GetString(fan, "speed"),
-						"direction":   GetString(fan, "direction"),
-						"model":       GetString(fan, "model"),
-						"serial":      GetString(fan, "serial"),
-						"status":      GetString(fan, "status"),
-						"drawer_name": GetString(fan, "drawer_name"),
-					}
-					results = append(results, NewCommonFields("fan", msg, n.Timestamp))
-				}
-			}
-		}
-	}
-	return results, nil
+var results []CommonFields
+for _, n := range notifications {
+for _, u := range n.Updates {
+vals, ok := u.Value.(map[string]interface{})
+if !ok {
+continue
+}
+if fanInfo := GetMap(vals, "FAN_INFO"); fanInfo != nil {
+fanList := AsMapSlice(fanInfo["FAN_INFO_LIST"])
+for _, fan := range fanList {
+msg := map[string]interface{}{
+"name":        GetString(fan, "name"),
+"speed":       GetString(fan, "speed"),
+"direction":   GetString(fan, "direction"),
+"model":       GetString(fan, "model"),
+"serial":      GetString(fan, "serial"),
+"status":      GetString(fan, "status"),
+"drawer_name": GetString(fan, "drawer_name"),
+}
+results = append(results, NewCommonFields("fan", msg, n.Timestamp))
+}
+}
+}
+}
+return results, nil
 }

--- a/src/TelemetryClient/internal/transform/system.go
+++ b/src/TelemetryClient/internal/transform/system.go
@@ -8,7 +8,7 @@ import (
 	"gnmi-collector/internal/gnmi"
 )
 
-const dataTypeSystemResources = "cisco_nexus_system_resources"
+const dataTypeSystemResources = "system_resources"
 
 func init() {
 	Register("system-cpus", func() Transformer { return &SystemResourcesTransformer{} })
@@ -155,7 +155,7 @@ func toFloat(v interface{}) float64 {
 	}
 }
 
-const dataTypeSystemUptime = "cisco_nexus_system_uptime"
+const dataTypeSystemUptime = "system_uptime"
 
 // SystemUptimeTransformer converts gNMI system state data to the schema
 // matching the current system-uptime parser.

--- a/src/TelemetryClient/internal/transform/transceiver.go
+++ b/src/TelemetryClient/internal/transform/transceiver.go
@@ -4,7 +4,7 @@ import (
 	"gnmi-collector/internal/gnmi"
 )
 
-const dataTypeTransceiver = "cisco_nexus_transceiver"
+const dataTypeTransceiver = "transceiver"
 
 func init() {
 	Register("transceiver", func() Transformer { return &TransceiverTransformer{} })

--- a/src/TelemetryClient/internal/transform/transceiver_channel.go
+++ b/src/TelemetryClient/internal/transform/transceiver_channel.go
@@ -4,7 +4,7 @@ import (
 	"gnmi-collector/internal/gnmi"
 )
 
-const dataTypeTransceiverChannel = "cisco_nexus_transceiver_dom"
+const dataTypeTransceiverChannel = "transceiver_dom"
 
 func init() {
 	Register("transceiver-channel", func() Transformer { return &TransceiverChannelTransformer{} })

--- a/src/TelemetryClient/internal/transform/transformer_test.go
+++ b/src/TelemetryClient/internal/transform/transformer_test.go
@@ -240,49 +240,35 @@ func TestEnvironmentTempTransformer(t *testing.T) {
 }
 
 func TestEnvironmentPowerTransformer(t *testing.T) {
-	notifications := loadTestData(t, "power-supply.json")
-	tr := &EnvironmentPowerTransformer{}
+notifications := loadTestData(t, "power-supply.json")
+tr := &EnvironmentPowerTransformer{}
 
-	results, err := tr.Transform(notifications)
-	if err != nil {
-		t.Fatalf("transform error: %v", err)
-	}
-
-	if len(results) != 1 {
-		t.Fatalf("expected 1 result, got %d", len(results))
-	}
-
-	msg, ok := results[0].Message.(map[string]interface{})
-	if !ok {
-		t.Fatal("message not a map")
-	}
-
-	supplies, ok := msg["power_supplies"]
-	if !ok {
-		t.Fatal("missing power_supplies")
-	}
-
-	psList, ok := supplies.([]map[string]interface{})
-	if !ok {
-		t.Fatalf("power_supplies is not []map, got %T", supplies)
-	}
-
-	if len(psList) != 2 {
-		t.Errorf("expected 2 PSUs, got %d", len(psList))
-	}
-
-	// Check base64 decode worked — capacity should be a numeric string, not base64
-	for _, ps := range psList {
-		if cap, ok := ps["total_capacity"].(string); ok {
-			if cap == "RIl9cQ==" {
-				t.Error("capacity was not decoded from base64")
-			}
-		}
-	}
-
-	t.Logf("Produced %d PSU entries", len(psList))
+results, err := tr.Transform(notifications)
+if err != nil {
+t.Fatalf("transform error: %v", err)
 }
 
+if len(results) < 2 {
+t.Fatalf("expected at least 2 PSU results (one per PSU), got %d", len(results))
+}
+
+// Each result is now a flat PSU entry
+for _, entry := range results {
+msg, ok := entry.Message.(map[string]interface{})
+if !ok {
+t.Fatal("message not a map")
+}
+
+// Check base64 decode worked - capacity should be a numeric string, not base64
+if cap, ok := msg["total_capacity"].(string); ok {
+if cap == "RIl9cQ==" {
+t.Error("capacity was not decoded from base64")
+}
+}
+}
+
+t.Logf("Produced %d PSU entries", len(results))
+}
 func TestInventoryTransformer(t *testing.T) {
 	notifications := loadTestData(t, "platform-inventory.json")
 	tr := &InventoryTransformer{}

--- a/src/TelemetryClient/internal/transform/transformer_test.go
+++ b/src/TelemetryClient/internal/transform/transformer_test.go
@@ -40,8 +40,8 @@ func TestInterfaceCountersTransformer(t *testing.T) {
 
 	// Check first result has required fields
 	entry := results[0]
-	if entry.DataType != "cisco_nexus_interface_counters" {
-		t.Errorf("data_type = %q, want cisco_nexus_interface_counters", entry.DataType)
+	if entry.DataType != "interface_counters" {
+		t.Errorf("data_type = %q, want interface_counters", entry.DataType)
 	}
 	if entry.Timestamp == "" {
 		t.Error("timestamp should not be empty")
@@ -80,7 +80,7 @@ func TestInterfaceStatusTransformer(t *testing.T) {
 	}
 
 	entry := results[0]
-	if entry.DataType != "cisco_nexus_interface_status" {
+	if entry.DataType != "interface_status" {
 		t.Errorf("data_type = %q", entry.DataType)
 	}
 


### PR DESCRIPTION
# Problem

The gnmi telemetry collector uses different YANG models per vendor (OpenConfig vs Cisco-native vs SONiC-native), which resulted in **vendor-prefixed table names** in Azure Log Analytics (e.g., `CiscoBgpSummary_CL` vs `SonicBgpSummary_CL`). This made cross-vendor dashboards and alerts impossible without UNION queries, and field names/types were inconsistent for the same logical data.

# Solution

Unify the telemetry schema so **both Cisco and SONiC write to the same tables** with consistent field names and types. The `device_type` field distinguishes the source vendor.

## Key changes

### 1. Schema unification (core)
- Remove `applyDataTypePrefix()` mechanism that prepended vendor names to data types
- Rename all `data_type` constants from vendor-prefixed (`cisco_nexus_bgp_summary`) to vendor-neutral (`bgp_summary`)
- Unify table names in both YAML configs:

| Before (Cisco) | Before (SONiC) | After (shared) |
|---|---|---|
| `CiscoBgpSummary_CL` | `SonicBgpSummary_CL` | `BgpNeighbor_CL` |
| `CiscoEnvTemperature_CL` | `SonicEnvTemperature_CL` | `EnvTemperature_CL` |
| `CiscoEnvPower_CL` | `SonicEnvPower_CL` | `EnvPower_CL` |
| — | `SonicFan_CL` | `EnvFan_CL` |
| `CiscoInterfaceCounter_CL` | `SonicInterfaceCounter_CL` | `InterfaceCounter_CL` |
| *(and 10+ more)* | | |

### 2. Field normalization
- **Temperature**: `major_threshold` → `high_threshold`, `minor_threshold` → `low_threshold` (SONiC naming is more descriptive and vendor-neutral)
- **Power supply**: `vin`/`iout`/`pout` → `input_voltage`/`output_current`/`output_power` (self-documenting); flattened from nested array to one row per PSU
- **MAC table**: Fixed `secure` and `ntfy` fields from `string` → `bool` in OpenConfig transformer to match Cisco-native
- **Timestamps**: Removed redundant `timestamp_ns`, keeping only `timestamp` (RFC3339Nano)
- **Message fields**: Flattened nested `Message` map to top-level keys (Log Analytics was auto-prefixing with `message_`)

### 3. New Cisco fan transformer
- Added `NativeEnvFanTransformer` (`nx-fan`) for `/System/ch-items/ftslot-items/FtSlot-list`
- Handles NX-OS nested structure: FtSlot → ft-items → Fan-list
- Both Cisco and SONiC now write to shared `EnvFan_CL` table

### 4. SONiC platform split
- Split monolithic `SonicPlatformTransformer` into 3 focused transformers: `SonicTemperatureTransformer`, `SonicPsuTransformer`, `SonicFanTransformer`
- Each writes to the appropriate shared table

### 5. Documentation
- Added `unified-schema.md` design document with full table mapping and migration guide
- Updated all parity docs, telemetry tables reference, onboarding guide, README, CHANGELOG

## ⚠️ Breaking changes
- **All table names changed** — existing KQL queries, workbooks, and alerts referencing old vendor-prefixed names (e.g., `CiscoBgpSummary_CL`) will need to be updated
- **Field names changed** in temperature and power supply tables
- Old tables in the Log Analytics workspace will remain but stop receiving data

## Testing
- All Go unit tests pass (`go test ./...`)
- Deployed and validated on both switches:
  - **Cisco NX-OS** (100.71.34.149): 21/21 subscriptions successful, all tables populated
  - **SONiC** (100.100.81.129): 16/16 subscriptions successful, all tables populated
- Fan data confirmed flowing to unified `EnvFan_CL` from both platforms

## Path counts
- **Cisco**: 21 enabled YANG paths (+ 9 disabled OC duplicates)
- **SONiC**: 16 enabled YANG paths (+ 4 disabled)

## Demo
https://github.com/user-attachments/assets/3f27e2f5-2b7d-4a62-bbb0-cd6e50d1a5ca


